### PR TITLE
Fix cookies not setting on Safari on localhost

### DIFF
--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -1,8 +1,13 @@
+import { WORKOS_REDIRECT_URI } from './env-variables.js';
+
+const redirectUrl = new URL(WORKOS_REDIRECT_URI);
+const isSecureProtocol = redirectUrl.protocol === 'https:';
+
 const cookieName = 'wos-session';
 const cookieOptions = {
   path: '/',
   httpOnly: true,
-  secure: true,
+  secure: isSecureProtocol,
   sameSite: 'lax' as const,
 };
 


### PR DESCRIPTION
This PR fixes the issue where Safari wouldn't set cookies when used for testing locally.

More info: https://codedamn.com/news/web-development/safari-cookie-is-not-being-set#:~:text=The%20Issue%20with,of%20web%20development.