### PR TITLE
export `cookieName`, `cookieOptions` and `encryptSession`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { handleAuth } from './authkit-callback-route.js';
 import { authkitMiddleware } from './middleware.js';
-import { getUser } from './session.js';
+import { getUser, encryptSession } from './session.js';
 import { getSignInUrl, getSignUpUrl, signOut } from './auth.js';
-import { cookieName } from './cookie.js';
+import { cookieName, cookieOptions } from './cookie.js';
 import { Impersonation } from './impersonation.js';
 
 export {
@@ -13,9 +13,11 @@ export {
   getSignInUrl,
   getSignUpUrl,
   getUser,
+  encryptSession,
   signOut,
   //
   cookieName,
+  cookieOptions,
   //
   Impersonation,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { handleAuth } from './authkit-callback-route.js';
 import { authkitMiddleware } from './middleware.js';
 import { getUser } from './session.js';
 import { getSignInUrl, getSignUpUrl, signOut } from './auth.js';
+import { cookieName } from './cookie.js';
 import { Impersonation } from './impersonation.js';
 
 export {
@@ -13,6 +14,8 @@ export {
   getSignUpUrl,
   getUser,
   signOut,
+  //
+  cookieName,
   //
   Impersonation,
 };


### PR DESCRIPTION
This PR export `cookieOptions`, `cookieName` and `encryptSession` from WorkOS. 
The motivation to do it is for people who try to implement the authentication themself and need to copy the code from this repository (that may change in the future). Also, I need to install `iron-session` as a dependency in my project if I implement it myself. 

Alternatively, I could create a function that sets the cookie like the SDK instead of writing this code the codebase:

```ts
        const session = await encryptSession({ accessToken, refreshToken, user, impersonator });
        cookies().set(cookieName, session, cookieOptions);
```


### Notes:
I still haven't organized everything properly with my implementation, but it seems like I need to export those parts from the SDK to implement it. Feel free to change or block this PR if you feel it's wrong :)