### PR TITLE
Use relative redirect location in AuthKit callback handler

### DIFF
--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -22,16 +22,8 @@ export function handleAuth(options: HandleAuthOptions = {}) {
           code,
         });
 
-        const url = request.nextUrl.clone();
-
-        // Cleanup params
-        url.searchParams.delete('code');
-        url.searchParams.delete('state');
-
         // Redirect to the requested path and store the session
-        url.pathname = returnPathname ?? returnPathnameOption;
-
-        const response = NextResponse.redirect(url);
+        const response = NextResponse.redirect(returnPathname ?? returnPathnameOption);
 
         if (!accessToken || !refreshToken) throw new Error('response is missing tokens');
 


### PR DESCRIPTION
Previously, by cloning the request URL, we were inheriting the `host` and constructing an absolute URL as the `Location`.

This is a problem in certain cases, like if the app is running behind a reverse-proxy. From the outside, requests to the proxy may be coming in as `example.com`, but the application may see something else like `localhost`.

We can avoid this by just using whatever was given as the `returnPathname`, or falling back to the default of `/` which is a relative URL.