### PR TITLE
Revert "Use relative redirect location (#35)"

### DIFF
--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -22,8 +22,16 @@ export function handleAuth(options: HandleAuthOptions = {}) {
           code,
         });
 
+        const url = request.nextUrl.clone();
+
+        // Cleanup params
+        url.searchParams.delete('code');
+        url.searchParams.delete('state');
+
         // Redirect to the requested path and store the session
-        const response = NextResponse.redirect(returnPathname ?? returnPathnameOption);
+        url.pathname = returnPathname ?? returnPathnameOption;
+
+        const response = NextResponse.redirect(url);
 
         if (!accessToken || !refreshToken) throw new Error('response is missing tokens');
 


### PR DESCRIPTION
Reverts the changes in #35, where are not[ compatible with more recent NextJS versions](https://nextjs.org/docs/messages/middleware-relative-urls) (> 12.1), which require an absolute URL:

> Prior to Next.js 12.1, we allowed passing relative URLs. However, constructing a request with new Request(url) or running fetch(url) when url is a relative URL does not work. For this reason and to bring consistency to Next.js Middleware, this behavior has been deprecated and now removed.

