### PR TITLE
Add API-related env variables for testing with other API servers

### DIFF
--- a/src/env-variables.ts
+++ b/src/env-variables.ts
@@ -1,4 +1,4 @@
-function getEnvVariable(name: string) {
+function getEnvVariable(name: string): string {
   const envVariable = process.env[name];
   if (!envVariable) {
     throw new Error(`${name} environment variable is not set`);
@@ -6,13 +6,28 @@ function getEnvVariable(name: string) {
   return envVariable;
 }
 
+function getOptionalEnvVariable(name: string): string | undefined {
+  return process.env[name];
+}
+
 const WORKOS_CLIENT_ID = getEnvVariable('WORKOS_CLIENT_ID');
 const WORKOS_API_KEY = getEnvVariable('WORKOS_API_KEY');
 const WORKOS_REDIRECT_URI = getEnvVariable('WORKOS_REDIRECT_URI');
 const WORKOS_COOKIE_PASSWORD = getEnvVariable('WORKOS_COOKIE_PASSWORD');
+const WORKOS_API_HOSTNAME = getOptionalEnvVariable('WORKOS_API_HOSTNAME');
+const WORKOS_API_HTTPS = getOptionalEnvVariable('WORKOS_API_HTTPS');
+const WORKOS_API_PORT = getOptionalEnvVariable('WORKOS_API_PORT');
 
 if (WORKOS_COOKIE_PASSWORD.length < 32) {
   throw new Error('WORKOS_COOKIE_PASSWORD must be at least 32 characters long');
 }
 
-export { WORKOS_CLIENT_ID, WORKOS_API_KEY, WORKOS_REDIRECT_URI, WORKOS_COOKIE_PASSWORD };
+export {
+  WORKOS_CLIENT_ID,
+  WORKOS_API_KEY,
+  WORKOS_REDIRECT_URI,
+  WORKOS_COOKIE_PASSWORD,
+  WORKOS_API_HOSTNAME,
+  WORKOS_API_HTTPS,
+  WORKOS_API_PORT,
+};

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,7 +1,14 @@
 import WorkOS from '@workos-inc/node';
-import { WORKOS_API_KEY } from './env-variables.js';
+import { WORKOS_API_HOSTNAME, WORKOS_API_HTTPS, WORKOS_API_KEY, WORKOS_API_PORT } from './env-variables.js';
+
+
+const options = {
+  apiHostname: WORKOS_API_HOSTNAME,
+  https: WORKOS_API_HTTPS ? WORKOS_API_HTTPS === 'true' : true,
+  port: WORKOS_API_PORT ? parseInt(WORKOS_API_PORT) : undefined,
+};
 
 // Initialize the WorkOS client
-const workos = new WorkOS(WORKOS_API_KEY);
+const workos = new WorkOS(WORKOS_API_KEY, options);
 
 export { workos };


### PR DESCRIPTION
This PR adds new environment variables for allowing testing SDK against other WorkOS API for development purposes:
- `WORKOS_API_HOSTNAME`
- `WORKOS_API_PORT`
- `WORKOS_API_HTTPS`
