### PR TITLE
Throw error on URI mismatch

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -40,6 +40,18 @@ async function updateSession(request: NextRequest, debug: boolean, middlewareAut
     return pathRegex.exec(request.nextUrl.pathname);
   });
 
+  const url = new URL(WORKOS_REDIRECT_URI);
+
+  if (
+    middlewareAuth.enabled &&
+    url.pathname === request.nextUrl.pathname &&
+    !middlewareAuth.unauthenticatedPaths.includes(url.pathname)
+  ) {
+    throw new Error(
+      `Mismatch detected: WorkOS redirect URI '${url.pathname}' found in middleware matcher but is not included in 'unauthenticatedPaths' array. This will cause a log in loop. Add '${url.pathname}' to 'unauthenticatedPaths' config to resolve.`,
+    );
+  }
+
   // If the user is logged out and this path isn't on the allowlist for logged out paths, redirect to AuthKit.
   if (middlewareAuth.enabled && matchedPaths.length === 0 && !session) {
     if (debug) console.log('Unauthenticated user on protected route, redirecting to AuthKit');


### PR DESCRIPTION
Fixes https://github.com/workos/authkit-nextjs/issues/40

In the case where you have:
* Middleware auth mode enabled
* Redirect URL in the middleware matcher
* Don't have the redirect URL in the `unauthenticatedPaths` array

You'd get stuck in a login loop as you'd be redirected to AuthKit before the session can be set establishing that you've already logged in.

This adds a check and throws an error in that case.