### PR TITLE
Add missing type

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -29,6 +29,7 @@ export interface NoUserInfo {
   organizationId?: undefined;
   role?: undefined;
   impersonator?: undefined;
+  accessToken?: undefined;
 }
 
 export interface AccessToken {


### PR DESCRIPTION
Adds missing type to the `NoUserInfo` interface.

Fixes https://github.com/workos/authkit-nextjs/issues/54