### PR TITLE
Add video tutorial to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ or
 yarn add @workos-inc/authkit-nextjs
 ```
 
+## Video tutorial
+
+<a href="https://youtu.be/gMkHOotg0xc?feature=shared" target="_blank">
+  <img src="https://github.com/user-attachments/assets/ed67129b-3b27-4745-8960-64db4c8ab393" alt="YouTube tutorial: Next.js App Router Authentication with AuthKit" style="display: block; width: 100%; max-width: 720px; height: auto; aspect-ratio: 16/9; object-fit: cover; object-position: center; margin: 1em auto;" onerror="this.onerror=null; this.src='https://img.youtube.com/vi/gMkHOotg0xc/0.jpg'" />
+</a>
+
 ## Pre-flight
 
 Make sure the following values are present in your `.env.local` environment variables file. The client ID and API key can be found in the [WorkOS dashboard](https://dashboard.workos.com), and the redirect URI can also be configured there.


### PR DESCRIPTION
Adds a link to the WorkOS video tutorial into the README.

Embeds are not directly supported. So I've uploaded an image with a YouTube style play icon atop it. It is styled to be responsive to the page size and fallback to YouTube hosted thumbnail.