### PR TITLE
Check for valid session when tab becomes active

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ export const config = { matcher: ['/', '/admin'] };
 
 ## Usage
 
+### Wrap your app in `AuthKitProvider`
+
+Use `AuthKitProvider` to wrap your app layout, which adds some protections for auth edge cases.
+
+```jsx
+import { AuthKitProvider } from '@workos-inc/authkit-nextjs';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <AuthKitProvider>{children}</AuthKitProvider>
+      </body>
+    </html>
+  );
+}
+```
+
 ### Get the current user
 
 For pages where you want to display a signed-in and signed-out view, use `getUser` to retrieve the user profile from WorkOS.

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,0 +1,10 @@
+'use server';
+
+/**
+ * This action is only accessible to authenticated users,
+ * there is no need to check the session here as the middleware will
+ * be responsible for that.
+ */
+export const checkSessionAction = async () => {
+  return true;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { authkitMiddleware } from './middleware.js';
 import { getUser } from './session.js';
 import { getSignInUrl, getSignUpUrl, signOut } from './auth.js';
 import { Impersonation } from './impersonation.js';
+import { Provider } from './provider.js';
 
 export {
   handleAuth,
@@ -15,4 +16,5 @@ export {
   signOut,
   //
   Impersonation,
+  Provider,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { authkitMiddleware } from './middleware.js';
 import { getUser } from './session.js';
 import { getSignInUrl, getSignUpUrl, signOut } from './auth.js';
 import { Impersonation } from './impersonation.js';
-import { Provider } from './provider.js';
+import { AuthKitProvider } from './provider.js';
 
 export {
   handleAuth,
@@ -16,5 +16,5 @@ export {
   signOut,
   //
   Impersonation,
-  Provider,
+  AuthKitProvider,
 };

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import * as React from 'react';
+import { checkSessionAction } from './actions.js';
+
+export const Provider = ({ children }: React.PropsWithChildren) => {
+  React.useLayoutEffect(() => {
+    const handleVisibilityChange = async () => {
+      if (document.visibilityState === 'visible') {
+        try {
+          const hasSession = await checkSessionAction();
+          if (!hasSession) {
+            throw new Error('Session expired');
+          }
+        } catch (error) {
+          window.location.reload();
+        }
+      }
+    };
+
+    window.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  return <>{children}</>;
+};

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { checkSessionAction } from './actions.js';
 
-export const Provider = ({ children }: React.PropsWithChildren) => {
+export const AuthKitProvider = ({ children }: React.PropsWithChildren) => {
   React.useEffect(() => {
     const handleVisibilityChange = async () => {
       if (document.visibilityState === 'visible') {
@@ -18,6 +18,9 @@ export const Provider = ({ children }: React.PropsWithChildren) => {
       }
     };
 
+    // In the case where we're using middleware auth mode, a user that has signed out in a different tab
+    // will run into an issue if they attempt to hit a server action in the original tab.
+    // This will force a refresh of the page in that case, which will redirect them to the sign-in page.
     window.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -3,30 +3,60 @@
 import * as React from 'react';
 import { checkSessionAction } from './actions.js';
 
-export const AuthKitProvider = ({ children }: React.PropsWithChildren) => {
+interface AuthKitProviderProps {
+  children: React.ReactNode;
+  /**
+   * Customize what happens when a session is expired. By default,the entire page will be reloaded.
+   * You can also pass this as `false` to disable the expired session checks.
+   */
+  onSessionExpired?: false | (() => void);
+}
+
+export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderProps) => {
   React.useEffect(() => {
+    // Return early if the session expired checks are disabled.
+    if (onSessionExpired === false) {
+      return;
+    }
+
+    let visibilityChangedCalled = false;
+
     const handleVisibilityChange = async () => {
+      if (visibilityChangedCalled) {
+        return;
+      }
+
+      // In the case where we're using middleware auth mode, a user that has signed out in a different tab
+      // will run into an issue if they attempt to hit a server action in the original tab.
+      // This will force a refresh of the page in that case, which will redirect them to the sign-in page.
       if (document.visibilityState === 'visible') {
+        visibilityChangedCalled = true;
+
         try {
           const hasSession = await checkSessionAction();
           if (!hasSession) {
             throw new Error('Session expired');
           }
         } catch (error) {
-          window.location.reload();
+          if (onSessionExpired) {
+            onSessionExpired();
+          } else {
+            window.location.reload();
+          }
+        } finally {
+          visibilityChangedCalled = false;
         }
       }
     };
 
-    // In the case where we're using middleware auth mode, a user that has signed out in a different tab
-    // will run into an issue if they attempt to hit a server action in the original tab.
-    // This will force a refresh of the page in that case, which will redirect them to the sign-in page.
     window.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('focus', handleVisibilityChange);
 
     return () => {
+      window.removeEventListener('focus', handleVisibilityChange);
       window.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, []);
+  }, [onSessionExpired]);
 
   return <>{children}</>;
 };

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { checkSessionAction } from './actions.js';
 
 export const Provider = ({ children }: React.PropsWithChildren) => {
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     const handleVisibilityChange = async () => {
       if (document.visibilityState === 'visible') {
         try {


### PR DESCRIPTION
## Description
Add a new `Provider` component that users should wrap their application in order to check for invalid sessions, in case for example, a tab stayed open for too long or the user signed out in a different tab.

If the user has a invalid session upon returning to a tab, the page will be reloaded so the middleware can take care of the redirection.

By forcing this page reload, we prevent [possible CORS issues](https://github.com/workos/authkit-nextjs/pull/68) as server actions would throw an error as you are not authenticated.

The current use of the `Provider` is to listen to tab events and check for invalid session, but we can eventually introduce new feature inside the Provider, like passing down the current user in a context so it can be accessed in client components.

## How does that work?

When the user switches back to the app, we make a call to a server action, which in Next.js world is just a `POST` request to the current route the user is in.

If the user has a valid session, the request will most likely be successful so we don't need to do anything.
But if the user does not have an active session, there are two outcomes:
- The user is in a protected page, the server action will fail because the of the middleware, so we can reload the page to let the middleware handle the redirection
- If the user is a `public` page, the server action will succeed and don't have to do anything

And also, if the user does not have the `middlewareAuth` enabled, the server action will also be successful, so we don't reload the page.


## Open questions
- Should this behaviour be configured via a prop, like `<Provider checkForInactiveTab />` ?
- Should we allow users to customize what to do in the case of a invalid session? For example instead of reloading, display a React component saying that they are logged out?