### PR TITLE
Make onSessionExpired default to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "commonjs",

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -12,7 +12,7 @@ interface AuthKitProviderProps {
   onSessionExpired?: false | (() => void);
 }
 
-export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderProps) => {
+export const AuthKitProvider = ({ children, onSessionExpired = false }: AuthKitProviderProps) => {
   React.useEffect(() => {
     // Return early if the session expired checks are disabled.
     if (onSessionExpired === false) {

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_HTTPS, WORKOS_API_KEY, WORKOS_API_PORT } from './env-variables.js';
 
-export const VERSION = '0.10.0';
+export const VERSION = '0.10.1';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
There's an issue where switching tabs will force a reload. This removes the session expired behaviour by default while we investigate the issue.