### PR TITLE
Build package using esm over cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.10.1",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
-  "type": "commonjs",
-  "main": "./dist/cjs/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "type": "module",
+  "main": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
   "files": [
     "dist",
     "src",
@@ -15,7 +15,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "prebuild": "npm run clean",
-    "build": "tsc --project tsconfig-cjs.json",
+    "build": "tsc --project tsconfig.json",
     "prepublishOnly": "npm run lint",
     "lint": "eslint \"src/**/*.ts*\"",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,3 +1,5 @@
+'use server';
+
 import { getAuthorizationUrl } from './get-authorization-url.js';
 import { cookies } from 'next/headers';
 import { cookieName } from './cookie.js';

--- a/src/authkit-provider.tsx
+++ b/src/authkit-provider.tsx
@@ -34,10 +34,12 @@ export const AuthKitProvider = ({ children, onSessionExpired = false }: AuthKitP
 
         try {
           const hasSession = await checkSessionAction();
+          console.log('has session', hasSession);
           if (!hasSession) {
             throw new Error('Session expired');
           }
         } catch (error) {
+          console.log('no session', error);
           if (onSessionExpired) {
             onSessionExpired();
           } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { authkitMiddleware } from './middleware.js';
 import { getUser, refreshSession } from './session.js';
 import { getSignInUrl, getSignUpUrl, signOut } from './auth.js';
 import { Impersonation } from './impersonation.js';
-import { AuthKitProvider } from './provider.js';
+import { AuthKitProvider } from './authkit-provider.js';
 
 export {
   handleAuth,

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,3 +1,5 @@
+'use server';
+
 import { redirect } from 'next/navigation';
 import { cookies, headers } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig-base.json",
-  "compilerOptions": {
-    "outDir": "./dist/cjs",
-    "module": "CommonJS"
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,16 +3,16 @@
     "target": "ES2018",
     "lib": ["DOM", "ESNext", "DOM.Iterable"],
     "jsx": "react",
-    "module": "ES2020",
-    "moduleResolution": "Node",
     "sourceMap": true,
     "declaration": true,
-    "outDir": "./dist",
     "importHelpers": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "alwaysStrict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "outDir": "./dist/esm",
+    "module": "ES2020",
+    "moduleResolution": "Node"
   }
 }


### PR DESCRIPTION
Next.js cannot resolve the server action when the bundle is cjs (and you have a mix of `use client ` and `use server`). So in my tests the `esm` output resolved the issue and I managed to integrate correctly with Next.js - fixing the bug related to `checkSessionAction` being `undefined`.