### PR TITLE
Add getSession

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,10 +196,8 @@ export default async function middleware(request: NextRequest) {
   // authkitMiddleware will handle refreshing the session if the access token has expired
   const response = await authkitMiddleware()(request);
 
-  const session = await getSession();
-
   // If session is undefined, the user is not authenticated
-  console.log('session:', session);
+  const session = await getSession(response);
 
   // ...add additional middleware logic here
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,32 @@ In the above example the `/admin` page will require a user to be signed in, wher
 
 `unauthenticatedPaths` uses the same glob logic as the [Next.js matcher](https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher).
 
+### Retrieve session in middleware
+
+Sometimes it's useful to check the user session if you want to compose custom middleware. The `getSession` helper method will retrieve the session from the cookie and verify the access token.
+
+```ts
+import { authkitMiddleware, getSession } from '@workos-inc/authkit-nextjs';
+import { NextRequest } from 'next/server';
+
+export default async function middleware(request: NextRequest) {
+  // authkitMiddleware will handle refreshing the session if the access token has expired
+  const response = await authkitMiddleware()(request);
+
+  const session = await getSession();
+
+  // If session is null, the user is not authenticated
+  console.log('session:', session);
+
+  // ...add additional middleware logic here
+
+  return response;
+}
+
+// Match against pages that require auth
+export const config = { matcher: ['/', '/account/:path*'] };
+```
+
 ### Signing out
 
 Use the `signOut` method to sign out the current logged in user and redirect to your app's homepage. The homepage redirect is set in your WorkOS dashboard settings under "Redirect".

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ export default async function middleware(request: NextRequest) {
 
   const session = await getSession();
 
-  // If session is null, the user is not authenticated
+  // If session is undefined, the user is not authenticated
   console.log('session:', session);
 
   // ...add additional middleware logic here

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { handleAuth } from './authkit-callback-route.js';
 import { authkitMiddleware } from './middleware.js';
-import { getUser, refreshSession } from './session.js';
+import { getUser, refreshSession, getSession } from './session.js';
 import { getSignInUrl, getSignUpUrl, signOut } from './auth.js';
 import { Impersonation } from './impersonation.js';
 import { AuthKitProvider } from './provider.js';
@@ -9,6 +9,7 @@ export {
   handleAuth,
   //
   authkitMiddleware,
+  getSession,
   //
   getSignInUrl,
   getSignUpUrl,

--- a/src/session.ts
+++ b/src/session.ts
@@ -248,6 +248,31 @@ async function getSessionFromCookie() {
   }
 }
 
+/**
+ * Retrieves the session from the cookie. Meant for use in the middleware, for client side use `getUser` instead.
+ *
+ * @returns Session | undefined
+ */
+async function getSession() {
+  const session = await getSessionFromCookie();
+
+  if (!session) return;
+
+  if (await verifyAccessToken(session.accessToken)) {
+    const { sid: sessionId, org_id: organizationId, role, permissions } = decodeJwt<AccessToken>(session.accessToken);
+
+    return {
+      sessionId,
+      user: session.user,
+      organizationId,
+      role,
+      permissions,
+      impersonator: session.impersonator,
+      accessToken: session.accessToken,
+    };
+  }
+}
+
 async function getSessionFromHeader(caller: string): Promise<Session | undefined> {
   const hasMiddleware = Boolean(headers().get(middlewareHeaderName));
 
@@ -269,4 +294,4 @@ function getReturnPathname(url: string): string {
   return `${newUrl.pathname}${newUrl.searchParams.size > 0 ? '?' + newUrl.searchParams.toString() : ''}`;
 }
 
-export { encryptSession, getUser, refreshSession, terminateSession, updateSession };
+export { encryptSession, getUser, refreshSession, terminateSession, updateSession, getSession };

--- a/src/session.ts
+++ b/src/session.ts
@@ -239,8 +239,8 @@ async function verifyAccessToken(accessToken: string) {
   }
 }
 
-async function getSessionFromCookie() {
-  const cookie = cookies().get(cookieName);
+async function getSessionFromCookie(response?: NextResponse) {
+  const cookie = response ? response.cookies.get(cookieName) : cookies().get(cookieName);
   if (cookie) {
     return unsealData<Session>(cookie.value, {
       password: WORKOS_COOKIE_PASSWORD,
@@ -253,8 +253,8 @@ async function getSessionFromCookie() {
  *
  * @returns Session | undefined
  */
-async function getSession() {
-  const session = await getSessionFromCookie();
+async function getSession(response?: NextResponse) {
+  const session = await getSessionFromCookie(response);
 
   if (!session) return;
 


### PR DESCRIPTION
Adds a new `getSession` helper method to retrieve the session in middleware. Fixes https://github.com/workos/authkit-nextjs/issues/72