### PR TITLE
Allow undefined redirect uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers';
 import { workos } from './workos.js';
 import { WORKOS_CLIENT_ID, WORKOS_COOKIE_NAME } from './env-variables.js';
 import { encryptSession } from './session.js';
-import { cookieOptions } from './cookie.js';
+import { getCookieOptions } from './cookie.js';
 import { HandleAuthOptions } from './interfaces.js';
 
 export function handleAuth(options: HandleAuthOptions = {}) {
@@ -52,7 +52,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
         const session = await encryptSession({ accessToken, refreshToken, user, impersonator });
         const cookieName = WORKOS_COOKIE_NAME || 'wos-session';
 
-        cookies().set(cookieName, session, cookieOptions);
+        cookies().set(cookieName, session, getCookieOptions(request.url));
 
         return response;
       } catch (error) {

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -1,18 +1,18 @@
 import { WORKOS_REDIRECT_URI, WORKOS_COOKIE_MAX_AGE, WORKOS_COOKIE_DOMAIN } from './env-variables.js';
+import { CookieOptions } from './interfaces.js';
 
-const redirectUrl = new URL(WORKOS_REDIRECT_URI);
-const isSecureProtocol = redirectUrl.protocol === 'https:';
+export function getCookieOptions(redirectUri?: string | null): CookieOptions {
+  const url = new URL(redirectUri || WORKOS_REDIRECT_URI);
 
-const cookieOptions = {
-  path: '/',
-  httpOnly: true,
-  secure: isSecureProtocol,
-  sameSite: 'lax' as const,
-  // Defaults to 400 days, the maximum allowed by Chrome
-  // It's fine to have a long cookie expiry date as the access/refresh tokens
-  // act as the actual time-limited aspects of the session.
-  maxAge: WORKOS_COOKIE_MAX_AGE ? parseInt(WORKOS_COOKIE_MAX_AGE, 10) : 60 * 60 * 24 * 400,
-  domain: WORKOS_COOKIE_DOMAIN,
-};
-
-export { cookieOptions };
+  return {
+    path: '/',
+    httpOnly: true,
+    secure: url.protocol === 'https:',
+    sameSite: 'lax' as const,
+    // Defaults to 400 days, the maximum allowed by Chrome
+    // It's fine to have a long cookie expiry date as the access/refresh tokens
+    // act as the actual time-limited aspects of the session.
+    maxAge: WORKOS_COOKIE_MAX_AGE ? parseInt(WORKOS_COOKIE_MAX_AGE, 10) : 60 * 60 * 24 * 400,
+    domain: WORKOS_COOKIE_DOMAIN,
+  };
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,3 +57,12 @@ export interface AuthkitMiddlewareOptions {
   middlewareAuth?: AuthkitMiddlewareAuth;
   redirectUri?: string;
 }
+
+export interface CookieOptions {
+  path: '/';
+  httpOnly: true;
+  secure: boolean;
+  sameSite: 'lax';
+  maxAge: number;
+  domain: string | undefined;
+}

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 
-export const VERSION = '0.11.1';
+export const VERSION = '0.11.2';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
We intended for the redirect URI to be configurable via either env variables or via the middleware config object, but it wasn't working as intended. This fixes that.