### PR TITLE
Fix issue with redirectURI in middleware auth mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",

--- a/src/get-authorization-url.ts
+++ b/src/get-authorization-url.ts
@@ -4,9 +4,9 @@ import { GetAuthURLOptions } from './interfaces.js';
 import { headers } from 'next/headers';
 
 async function getAuthorizationUrl(options: GetAuthURLOptions = {}) {
-  const { returnPathname, screenHint, organizationId } = options;
+  const { returnPathname, screenHint, organizationId, redirectUri: redirectUriOptions } = options;
 
-  const redirectUri = headers().get('x-redirect-uri');
+  const redirectUri = redirectUriOptions ?? headers().get('x-redirect-uri');
 
   return workos.userManagement.getAuthorizationUrl({
     provider: 'authkit',

--- a/src/get-authorization-url.ts
+++ b/src/get-authorization-url.ts
@@ -4,9 +4,7 @@ import { GetAuthURLOptions } from './interfaces.js';
 import { headers } from 'next/headers';
 
 async function getAuthorizationUrl(options: GetAuthURLOptions = {}) {
-  const { returnPathname, screenHint, organizationId, redirectUri: redirectUriOptions } = options;
-
-  const redirectUri = redirectUriOptions ?? headers().get('x-redirect-uri');
+  const { returnPathname, screenHint, organizationId, redirectUri = headers().get('x-redirect-uri') } = options;
 
   return workos.userManagement.getAuthorizationUrl({
     provider: 'authkit',

--- a/src/session.ts
+++ b/src/session.ts
@@ -81,7 +81,9 @@ async function updateSession(
   if (middlewareAuth.enabled && matchedPaths.length === 0 && !session) {
     if (debug) console.log('Unauthenticated user on protected route, redirecting to AuthKit');
 
-    return NextResponse.redirect(await getAuthorizationUrl({ returnPathname: getReturnPathname(request.url) }));
+    return NextResponse.redirect(
+      await getAuthorizationUrl({ returnPathname: getReturnPathname(request.url), redirectUri: redirectUri ?? '' }),
+    );
   }
 
   // If no session, just continue

--- a/src/session.ts
+++ b/src/session.ts
@@ -82,7 +82,10 @@ async function updateSession(
     if (debug) console.log('Unauthenticated user on protected route, redirecting to AuthKit');
 
     return NextResponse.redirect(
-      await getAuthorizationUrl({ returnPathname: getReturnPathname(request.url), redirectUri: redirectUri ?? '' }),
+      await getAuthorizationUrl({
+        returnPathname: getReturnPathname(request.url),
+        redirectUri: redirectUri ?? WORKOS_REDIRECT_URI,
+      }),
     );
   }
 

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 
-export const VERSION = '0.12.0';
+export const VERSION = '0.12.1';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
We set the redirectURI as a header, which isn't immediately available in middleware auth mode as it's the same request. Fix is to provide the redirect URI directly. 