### PR TITLE
Only try to parse state if it's available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -12,7 +12,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
   return async function GET(request: NextRequest) {
     const code = request.nextUrl.searchParams.get('code');
     const state = request.nextUrl.searchParams.get('state');
-    let returnPathname = state ? JSON.parse(atob(state)).returnPathname : null;
+    let returnPathname = state && state !== 'null' ? JSON.parse(atob(state)).returnPathname : null;
 
     if (code) {
       try {

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 
-export const VERSION = '0.12.1';
+export const VERSION = '0.12.2';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
Fixes https://github.com/workos/authkit-nextjs/issues/96

We always assumed that `state` would be set in the callback URI, however that's not the case with invitations. This adds a safety check before trying to parse.