### PR TITLE
Fix bug with redirect URI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",
@@ -21,7 +21,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@workos-inc/node": "7.27.4",
+    "@workos-inc/node": "^7.27.5",
     "iron-session": "^8.0.1",
     "jose": "^5.2.3",
     "path-to-regexp": "^6.2.2"

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,12 @@
 import { NextMiddleware } from 'next/server';
 import { updateSession } from './session.js';
 import { AuthkitMiddlewareOptions } from './interfaces.js';
+import { WORKOS_REDIRECT_URI } from './env-variables.js';
 
 export function authkitMiddleware({
   debug = false,
   middlewareAuth = { enabled: false, unauthenticatedPaths: [] },
-  redirectUri = '',
+  redirectUri = WORKOS_REDIRECT_URI,
 }: AuthkitMiddlewareOptions = {}): NextMiddleware {
   return function (request) {
     return updateSession(request, debug, middlewareAuth, redirectUri);

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 
-export const VERSION = '0.12.2';
+export const VERSION = '0.12.3';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
Fixes bug where the redirect URI was set to an empty string by default, overriding the environment variable. Also updates the workos-node version and sets it to "compatible with version" (caret ^ mode). We previously disabled this to pin a specific version which is no longer required.

Fixes https://github.com/workos/authkit-nextjs/issues/107

