### PR TITLE
Fix `signOut` for custom cookie domains

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,7 +3,7 @@
 import { getAuthorizationUrl } from './get-authorization-url.js';
 import { cookies } from 'next/headers';
 import { terminateSession } from './session.js';
-import { WORKOS_COOKIE_NAME } from './env-variables.js';
+import { WORKOS_COOKIE_NAME, WORKOS_COOKIE_DOMAIN } from './env-variables.js';
 
 async function getSignInUrl({ organizationId }: { organizationId?: string } = {}) {
   return getAuthorizationUrl({ organizationId, screenHint: 'sign-in' });
@@ -14,8 +14,11 @@ async function getSignUpUrl() {
 }
 
 async function signOut() {
-  const cookieName = WORKOS_COOKIE_NAME || 'wos-session';
-  cookies().delete(cookieName);
+  const cookie: { name: string; domain?: string } = {
+    name: WORKOS_COOKIE_NAME || 'wos-session',
+  };
+  if (WORKOS_COOKIE_DOMAIN) cookie.domain = WORKOS_COOKIE_DOMAIN;
+  cookies().delete(cookie);
   await terminateSession();
 }
 


### PR DESCRIPTION
The `signOut` method in auth.ts does not delete cookies set with a custom domain. This PR lets `signOut` delete custom domain cookies by checking if a custom domain has been set for the cookie. If so, it adds the custom domain to the keys that `cookies().delete()` (Nextjs' ResponseCookie's delete method) matches against, now finding the cookie and deleting it.

This lets authkit-nextjs work for applications that use a subdomain per customer (ex. `customer1.myenterpriseco.com`).