### PR TITLE
Add fallback for NextResponse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",
@@ -38,7 +38,7 @@
     "eslint": "^8.29.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-require-extensions": "^0.1.3",
-    "next": "^14.1.3",
+    "next": "^15.0.1",
     "prettier": "^3.3.3",
     "typescript": "5.4.2",
     "typescript-eslint": "^7.2.0"

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 
-export const VERSION = '0.13.0';
+export const VERSION = '0.13.1';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
`NextResponse` isn't always available in context in Next 13. This adds a fallback to using regular `Response` in those cases.

Tested in Next 13, 14 and 15.