### PR TITLE
Add signUpPaths configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,18 @@ Use the `refreshSession` method in a server action or route handler to fetch the
 
 The `organizationId` parameter can be passed to `refreshSession` in order to switch the session to a different organization. If the current session is not authorized for the next organization, an appropriate [authentication error](https://workos.com/docs/reference/user-management/authentication-errors) will be returned.
 
+### Sign up paths
+
+The `signUpPaths` option can be passed to `authkitMiddleware` to specify paths that should use the 'sign-up' screen hint when redirecting to AuthKit. This is useful for cases where you want a path that mandates authentication to be treated as a sign up page.
+
+```ts
+import { authkitMiddleware } from '@workos-inc/authkit-nextjs';
+
+export default authkitMiddleware({
+  signUpPaths: ['/account/sign-up'],
+});
+```
+
 ### Debugging
 
 To enable debug logs, initialize the middleware with the debug flag enabled.

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ The `signUpPaths` option can be passed to `authkitMiddleware` to specify paths t
 import { authkitMiddleware } from '@workos-inc/authkit-nextjs';
 
 export default authkitMiddleware({
-  signUpPaths: ['/account/sign-up'],
+  signUpPaths: ['/account/sign-up', '/dashboard/:path*'],
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The middleware can be configured with several options.
 | `redirectUri`    | `undefined` | Used in cases where you need your redirect URI to be set dynamically (e.g. Vercel preview deployments) |
 | `middlewareAuth` | `undefined` | Used to configure middleware auth options. See [middleware auth](#middleware-auth) for more details.   |
 | `debug`          | `false`     | Enables debug logs.                                                                                    |
+| `signUpPaths`    | `[]`        | Used to specify paths that should use the 'sign-up' screen hint when redirecting to AuthKit.           |
 
 #### Custom redirect URI
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,6 +57,7 @@ export interface AuthkitMiddlewareOptions {
   debug?: boolean;
   middlewareAuth?: AuthkitMiddlewareAuth;
   redirectUri?: string;
+  signUpPaths?: string[];
 }
 
 export interface CookieOptions {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,8 +7,9 @@ export function authkitMiddleware({
   debug = false,
   middlewareAuth = { enabled: false, unauthenticatedPaths: [] },
   redirectUri = WORKOS_REDIRECT_URI,
+  signUpPaths = [],
 }: AuthkitMiddlewareOptions = {}): NextMiddleware {
   return function (request) {
-    return updateSession(request, debug, middlewareAuth, redirectUri);
+    return updateSession(request, debug, middlewareAuth, redirectUri, signUpPaths);
   };
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -363,7 +363,8 @@ function getScreenHint(signUpPaths: string[] | string | undefined, pathname: str
   if (!signUpPaths) return 'sign-in';
 
   if (!Array.isArray(signUpPaths)) {
-    return signUpPaths.includes(pathname) ? 'sign-up' : 'sign-in';
+    const pathRegex = getMiddlewareAuthPathRegex(signUpPaths);
+    return pathRegex.exec(pathname) ? 'sign-up' : 'sign-in';
   }
 
   const screenHintPaths: string[] = signUpPaths.filter((pathGlob) => {


### PR DESCRIPTION
Fixes https://github.com/workos/authkit-nextjs/issues/121

Adds `signUpPaths` to middleware configuration, which allows you to specify which paths should show the "sign up" screen hint over the default "sign in".