### PR TITLE
Adds configurable baseURL in the auth redirect route

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ You can also control the pathname the user will be sent to after signing-in by p
 export const GET = handleAuth({ returnPathname: '/dashboard' });
 ```
 
+`handleAuth` can be used with several options.
+
+| Option           | Default     | Description                                                                                                                                                                                           |
+| ---------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `returnPathname` | `/`         | The pathname to redirect the user to after signing in                                                                                                                                                 |
+| `baseURL`        | `undefined` | The base URL to use for the redirect URI instead of the one in the request. Useful if the app is being run in a container like docker where the hostname can be different from the one in the request |
+
 ### Middleware
 
 This library relies on [Next.js middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware) to provide session management for routes. Put the following in your `middleware.ts` file in the root of your project:
@@ -93,6 +100,14 @@ export default authkitMiddleware();
 // Leave this out if you want auth on every resource (including images, css etc.)
 export const config = { matcher: ['/', '/admin'] };
 ```
+
+The middleware can be configured with several options.
+
+| Option           | Default     | Description                                                                                            |
+| ---------------- | ----------- | ------------------------------------------------------------------------------------------------------ |
+| `redirectUri`    | `undefined` | Used in cases where you need your redirect URI to be set dynamically (e.g. Vercel preview deployments) |
+| `middlewareAuth` | `undefined` | Used to configure middleware auth options. See [middleware auth](#middleware-auth) for more details.   |
+| `debug`          | `false`     | Enables debug logs.                                                                                    |
 
 #### Custom redirect URI
 
@@ -281,16 +296,6 @@ export default async function HomePage() {
 Use the `refreshSession` method in a server action or route handler to fetch the latest session details, including any changes to the user's roles or permissions.
 
 The `organizationId` parameter can be passed to `refreshSession` in order to switch the session to a different organization. If the current session is not authorized for the next organization, an appropriate [authentication error](https://workos.com/docs/reference/user-management/authentication-errors) will be returned.
-
-### Debugging
-
-To enable debug logs, initialize the middleware with the debug flag enabled.
-
-```js
-import { authkitMiddleware } from '@workos-inc/authkit-nextjs';
-
-export default authkitMiddleware({ debug: true });
-```
 
 ### Troubleshooting
 

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -31,7 +31,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
           code,
         });
 
-        // If baseURL is provided, use it instead of the hostname in nextURL
+        // If baseURL is provided, use it instead of request.nextUrl
         // This is useful if the app is being run in a container like docker where
         // the hostname can be different from the one in the request
         const url = baseURL ? new URL(baseURL) : request.nextUrl.clone();

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,6 +2,7 @@ import { User } from '@workos-inc/node';
 
 export interface HandleAuthOptions {
   returnPathname?: string;
+  baseURL?: string;
 }
 
 export interface Impersonator {


### PR DESCRIPTION
Fixes https://github.com/workos/authkit-nextjs/issues/37

Adds a new `baseURL` configuration option to `handleAuth`. This is to circumvent scenarios where `request.nextUrl` points to an internal URL rather than the intended one. 