### PR TITLE
expose workos client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { withAuth, refreshSession, getSession } from './session.js';
 import { getSignInUrl, getSignUpUrl, signOut } from './auth.js';
 import { Impersonation } from './impersonation.js';
 import { AuthKitProvider } from './authkit-provider.js';
+import { workos } from './workos.js';
 
 export {
   handleAuth,
@@ -19,4 +20,6 @@ export {
   //
   Impersonation,
   AuthKitProvider,
+  //
+  workos,
 };


### PR DESCRIPTION
In many cases you need access to the workos client. Instead of defining a new client we can just expose this one.