### PR TITLE
Move `oauthTokens` out of `Session` and make available via a new `onSuccess` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,23 @@ You can also control the pathname the user will be sent to after signing-in by p
 export const GET = handleAuth({ returnPathname: '/dashboard' });
 ```
 
-`handleAuth` can be used with several options.
+If you're application needs to persist data upon a successful authentication like the `oauthTokens` from an upstream provider, you can pass the `onSuccess` option:
+
+```ts
+export const GET = handleAUth({
+  onSuccess: async ({ oauthTokens }) => {
+    await saveTokens(oauthTokens);
+  },
+});
+```
+
+`handleAuth` can be used with the following options.
 
 | Option           | Default     | Description                                                                                                                                                                                           |
 | ---------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `returnPathname` | `/`         | The pathname to redirect the user to after signing in                                                                                                                                                 |
 | `baseURL`        | `undefined` | The base URL to use for the redirect URI instead of the one in the request. Useful if the app is being run in a container like docker where the hostname can be different from the one in the request |
+| `onSuccess`      | `undefined` | A function that receives successful authentication data and can be used for side-effects like persisting tokens                                                                                       |
 
 ### Middleware
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can also control the pathname the user will be sent to after signing-in by p
 export const GET = handleAuth({ returnPathname: '/dashboard' });
 ```
 
-If you're application needs to persist data upon a successful authentication like the `oauthTokens` from an upstream provider, you can pass the `onSuccess` option:
+If your application needs to persist data upon a successful authentication, like the `oauthTokens` from an upstream provider, you can pass in a `onSuccess` function that will get called after the user has successfully authenticated:
 
 ```ts
 export const GET = handleAUth({

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -7,7 +7,7 @@ import { getCookieOptions } from './cookie.js';
 import { HandleAuthOptions } from './interfaces.js';
 
 export function handleAuth(options: HandleAuthOptions = {}) {
-  const { returnPathname: returnPathnameOption = '/', baseURL } = options;
+  const { returnPathname: returnPathnameOption = '/', baseURL, onSuccess } = options;
 
   // Throw early if baseURL is provided but invalid
   if (baseURL) {
@@ -26,10 +26,11 @@ export function handleAuth(options: HandleAuthOptions = {}) {
     if (code) {
       try {
         // Use the code returned to us by AuthKit and authenticate the user with WorkOS
-        const { accessToken, refreshToken, user, impersonator, oauthTokens } = await workos.userManagement.authenticateWithCode({
-          clientId: WORKOS_CLIENT_ID,
-          code,
-        });
+        const { accessToken, refreshToken, user, impersonator, oauthTokens } =
+          await workos.userManagement.authenticateWithCode({
+            clientId: WORKOS_CLIENT_ID,
+            code,
+          });
 
         // If baseURL is provided, use it instead of request.nextUrl
         // This is useful if the app is being run in a container like docker where
@@ -68,9 +69,13 @@ export function handleAuth(options: HandleAuthOptions = {}) {
 
         if (!accessToken || !refreshToken) throw new Error('response is missing tokens');
 
+        if (onSuccess) {
+          await onSuccess({ accessToken, refreshToken, user, impersonator, oauthTokens });
+        }
+
         // The refreshToken should never be accesible publicly, hence why we encrypt it in the cookie session
         // Alternatively you could persist the refresh token in a backend database
-        const session = await encryptSession({ accessToken, refreshToken, user, impersonator, oauthTokens });
+        const session = await encryptSession({ accessToken, refreshToken, user, impersonator });
         const cookieName = WORKOS_COOKIE_NAME || 'wos-session';
         const nextCookies = await cookies();
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,6 +3,11 @@ import { OauthTokens, User } from '@workos-inc/node';
 export interface HandleAuthOptions {
   returnPathname?: string;
   baseURL?: string;
+  onSuccess?: (data: HandleAuthSuccessData) => void | Promise<void>;
+}
+
+export interface HandleAuthSuccessData extends Session {
+  oauthTokens?: OauthTokens;
 }
 
 export interface Impersonator {
@@ -14,7 +19,6 @@ export interface Session {
   refreshToken: string;
   user: User;
   impersonator?: Impersonator;
-  oauthTokens?: OauthTokens;
 }
 
 export interface UserInfo {
@@ -25,7 +29,6 @@ export interface UserInfo {
   permissions?: string[];
   entitlements?: string[];
   impersonator?: Impersonator;
-  oauthTokens?: OauthTokens;
   accessToken: string;
 }
 export interface NoUserInfo {
@@ -35,7 +38,6 @@ export interface NoUserInfo {
   role?: undefined;
   permissions?: undefined;
   impersonator?: undefined;
-  oauthTokens?: undefined;
   accessToken?: undefined;
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -150,7 +150,6 @@ async function updateSession(
       refreshToken,
       user,
       impersonator,
-      oauthTokens: session.oauthTokens,
     });
 
     newRequestHeaders.set(sessionHeaderName, encryptedSession);
@@ -306,7 +305,6 @@ async function withAuth({ ensureSignedIn = false } = {}) {
     permissions,
     entitlements,
     impersonator: session.impersonator,
-    oauthTokens: session.oauthTokens,
     accessToken: session.accessToken,
   };
 }


### PR DESCRIPTION
This follows the pattern that was recently introduced in workos/authkit-remix#33:

> Instead of storing these tokens in the session, this branch proposes making them only available as part of the initial > callback. Developers who need access to the underlying OAuth provider's tokens and API will be responsible for persisting them in their own data store for later usage.

The equivalent usage with `workos/authkit-next` looks like this:

```ts
import { handleAuth } from '@workos-inc/authkit-nextjs';

export const GET = handleAuth({
  onSuccess: async ({ oauthTokens }) => {
    await saveTokens(oauthTokens);
  },
});
```

