### PR TITLE
Only redirect after refresh failure in middleware auth mode

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -161,7 +161,7 @@ async function updateSession(
     response.cookies.set(cookieName, encryptedSession, getCookieOptions(redirectUri));
     return response;
   } catch (e) {
-    if (debug) console.log('Failed to refresh. Deleting cookie and redirecting.', e);
+    if (debug) console.log('Failed to refresh. Deleting cookie.', e);
 
     nextCookies.delete(cookieName);
   }
@@ -171,6 +171,7 @@ async function updateSession(
     // We redirect to the current URL which will trigger the middleware again.
     // This is outside of the above block because you cannot redirect in Next.js
     // from inside a try/catch block.
+    if (debug) console.log('Redirecting to AuthKit to log in again.');
     return NextResponse?.redirect
       ? NextResponse.redirect(request.url)
       : new Response(null, {
@@ -180,6 +181,13 @@ async function updateSession(
           },
         });
   }
+
+  // If we aren't in middleware auth mode, we return a response and let the page handle what to do next.
+  const response = NextResponse.next({
+    request: { headers: newRequestHeaders },
+  });
+
+  return response;
 }
 
 async function refreshSession(options: {

--- a/src/session.ts
+++ b/src/session.ts
@@ -166,18 +166,20 @@ async function updateSession(
     nextCookies.delete(cookieName);
   }
 
-  // If we get here, the session is invalid and the user needs to sign in again.
-  // We redirect to the current URL which will trigger the middleware again.
-  // This is outside of the above block because you cannot redirect in Next.js
-  // from inside a try/catch block.
-  return NextResponse?.redirect
-    ? NextResponse.redirect(request.url)
-    : new Response(null, {
-        status: 307,
-        headers: {
-          Location: request.url,
-        },
-      });
+  if (middlewareAuth.enabled) {
+    // If we get here, the session is invalid and the user needs to sign in again because we're using middleware auth mode.
+    // We redirect to the current URL which will trigger the middleware again.
+    // This is outside of the above block because you cannot redirect in Next.js
+    // from inside a try/catch block.
+    return NextResponse?.redirect
+      ? NextResponse.redirect(request.url)
+      : new Response(null, {
+          status: 307,
+          headers: {
+            Location: request.url,
+          },
+        });
+  }
 }
 
 async function refreshSession(options: {


### PR DESCRIPTION
Changes our previous behaviour slightly where we would redirect if a refresh failed. Unless we're in middleware auth mode, the page itself should decide on whether a redirect is needed as it could contain content that's meant to be viewable when a user isn't logged in.