### PR TITLE
Bump to `v0.17.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-nextjs",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^7.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 
-export const VERSION = '0.16.2';
+export const VERSION = '0.17.0';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
Releases version `v0.17.0` which currently contains these public-facing changes:

* #154 