### PR TITLE
Exclude tests from build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 
-export const VERSION = '0.17.0';
+export const VERSION = '0.17.1';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,11 +12,11 @@
     "alwaysStrict": true,
     "skipLibCheck": true,
     "outDir": "./dist/esm",
+    "declarationDir": "./dist/esm/types",
     "module": "ES2020",
     "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "declarationDir": "./dist/types"
+    "allowSyntheticDefaultImports": true
   },
-  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "jest.config.ts", "jest.setup.ts"]
+  "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "jest.config.ts", "jest.setup.ts", "/dist/**/*", "__tests__/**/*"]
 }
 


### PR DESCRIPTION
Fixes https://github.com/workos/authkit-nextjs/issues/158

A test helper was added which doesn't have the `spec.tsx` suffix, causing it to included in the build. This updates tsconfig to ignore everything in the test directory.