### PR TITLE
fix: match type declaration dir in package.json with updated tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "sideEffects": false,
   "type": "module",
   "main": "./dist/esm/index.js",
-  "types": "./dist/esm/index.d.ts",
+  "types": "./dist/esm/types/index.d.ts",
   "files": [
     "dist",
     "src",


### PR DESCRIPTION
### What went wrong:

package.json is pointing to the wrong filepath for type declarations—upgrading this dependency to 0.17.1 causes typescript linting to break in downstream projects.

This problem began in 0.17.0, and was also modified in [0.17.1](https://github.com/workos/authkit-nextjs/pull/159/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0R15).

### In this PR:

package.json should now point to the same `{declarationDir}/index.d.ts` as specified in tsconfig.json