### PR TITLE
Add fallbackRedirect for blocked routes

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -59,6 +59,7 @@ export interface GetAuthURLOptions {
 export interface AuthkitMiddlewareAuth {
   enabled: boolean;
   unauthenticatedPaths: string[];
+  fallbackRedirectUri?: string;
 }
 
 export interface AuthkitMiddlewareOptions {

--- a/src/session.ts
+++ b/src/session.ts
@@ -98,7 +98,7 @@ async function updateSession(
   if (middlewareAuth.enabled && matchedPaths.length === 0 && !session) {
     if (debug) console.log(`Unauthenticated user on protected route ${request.url}, redirecting to AuthKit`);
 
-    const redirectTo = await getAuthorizationUrl({
+    const redirectTo = middlewareAuth.fallbackRedirectUri ?? await getAuthorizationUrl({
       returnPathname: getReturnPathname(request.url),
       redirectUri: redirectUri,
       screenHint: getScreenHint(signUpPaths, request.nextUrl.pathname),


### PR DESCRIPTION
Hello, WorkOS team!

I’m building my own UI, and I noticed an issue with the authentication middleware. It currently redirects users to the WorkOS authentication page by default.

To address this, I added a new property that allows overriding this URL, enabling me to redirect users to my custom sign-in route instead.

Let me know if there’s anything I should adjust or improve.

![a-little-girl-is-sitting-in-a-bathtub-eating-a-cookie-and-making-a-funny-face](https://github.com/user-attachments/assets/b638c0fd-39a3-46eb-81f3-8fe6b98a250d)
