### PR TITLE
Version 1.0.0

### DIFF
--- a/__tests__/session.spec.ts
+++ b/__tests__/session.spec.ts
@@ -343,7 +343,7 @@ describe('session.ts', () => {
       expect(console.log).toHaveBeenNthCalledWith(
         2,
         'Failed to refresh. Deleting cookie.',
-        new Error('Failed to refresh'),
+        new Error('Failed to refresh session: Failed to refresh'),
       );
     });
 
@@ -564,7 +564,7 @@ describe('session.ts', () => {
         expect(console.log).toHaveBeenNthCalledWith(
           2,
           'Failed to refresh. Deleting cookie.',
-          new Error('Failed to refresh'),
+          new Error('Failed to refresh session: Failed to refresh'),
         );
 
         expect(console.log).toHaveBeenNthCalledWith(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.17.2",
+  "version": "1.0.0",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 
-export const VERSION = '0.17.2';
+export const VERSION = '1.0.0';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
v1 release of authkit-next 🎉 

This release includes:

* Composable middleware
* Client side auth with hooks
* Using `AuthKitProvider` in client components no longer breaks the build
* Better DX around cookie errors
* 100% test coverage

This PR also fixes 2 failing tests.