### PR TITLE
Fix cookie bugs

### DIFF
--- a/__tests__/cookie.spec.ts
+++ b/__tests__/cookie.spec.ts
@@ -46,6 +46,40 @@ describe('cookie.ts', () => {
           domain: 'foobar.com',
         }),
       );
+
+      Object.defineProperty(envVars, 'WORKOS_COOKIE_DOMAIN', { value: '' });
+
+      const options2 = getCookieOptions('http://example.com');
+      expect(options2).toEqual(
+        expect.objectContaining({
+          secure: false,
+          maxAge: 1000,
+          domain: '',
+        }),
+      );
+
+      const options3 = getCookieOptions('https://example.com', true);
+
+      expect(options3).toEqual(expect.stringContaining('Domain='));
+    });
+
+    it('should return the cookie options with expired set to true', async () => {
+      const { getCookieOptions } = await import('../src/cookie');
+      const options = getCookieOptions('http://example.com', false, true);
+      expect(options).toEqual(expect.objectContaining({ maxAge: 0 }));
+    });
+
+    it('should return the cookie options as a string', async () => {
+      const { getCookieOptions } = await import('../src/cookie');
+      const options = getCookieOptions('http://example.com', true, false);
+      expect(options).toEqual(
+        expect.stringContaining('Path=/; HttpOnly; Secure=false; SameSite="Lax"; Max-Age=34560000; Domain=example.com'),
+      );
+
+      const options2 = getCookieOptions('https://example.com', true, true);
+      expect(options2).toEqual(
+        expect.stringContaining('Path=/; HttpOnly; Secure=true; SameSite="Lax"; Max-Age=0; Domain=example.com'),
+      );
     });
   });
 });

--- a/__tests__/utils.spec.ts
+++ b/__tests__/utils.spec.ts
@@ -16,10 +16,20 @@ describe('utils', () => {
 
       const result = redirectWithFallback(redirectUrl);
 
-      expect(mockRedirect).toHaveBeenCalledWith(redirectUrl);
+      expect(mockRedirect).toHaveBeenCalledWith(redirectUrl, { headers: undefined });
       expect(result).toBe('redirected');
 
       NextResponse.redirect = originalRedirect;
+    });
+
+    it('uses headers when provided', () => {
+      const redirectUrl = 'https://example.com';
+      const headers = new Headers();
+      headers.set('Set-Cookie', 'test=1');
+
+      const result = redirectWithFallback(redirectUrl, headers);
+
+      expect(result.headers.get('Set-Cookie')).toBe('test=1');
     });
 
     it('falls back to standard Response when NextResponse exists but redirect is undefined', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -5,7 +5,7 @@ import { WORKOS_CLIENT_ID, WORKOS_COOKIE_NAME } from './env-variables.js';
 import { encryptSession } from './session.js';
 import { errorResponseWithFallback, redirectWithFallback } from './utils.js';
 import { getCookieOptions } from './cookie.js';
-import { HandleAuthOptions } from './interfaces.js';
+import { CookieOptions, HandleAuthOptions } from './interfaces.js';
 
 export function handleAuth(options: HandleAuthOptions = {}) {
   const { returnPathname: returnPathnameOption = '/', baseURL, onSuccess } = options;
@@ -73,7 +73,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
         const cookieName = WORKOS_COOKIE_NAME || 'wos-session';
         const nextCookies = await cookies();
 
-        nextCookies.set(cookieName, session, getCookieOptions(request.url));
+        nextCookies.set(cookieName, session, getCookieOptions(request.url) as CookieOptions);
 
         return response;
       } catch (error) {

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -5,7 +5,7 @@ import { WORKOS_CLIENT_ID, WORKOS_COOKIE_NAME } from './env-variables.js';
 import { encryptSession } from './session.js';
 import { errorResponseWithFallback, redirectWithFallback } from './utils.js';
 import { getCookieOptions } from './cookie.js';
-import { CookieOptions, HandleAuthOptions } from './interfaces.js';
+import { HandleAuthOptions } from './interfaces.js';
 
 export function handleAuth(options: HandleAuthOptions = {}) {
   const { returnPathname: returnPathnameOption = '/', baseURL, onSuccess } = options;
@@ -73,7 +73,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
         const cookieName = WORKOS_COOKIE_NAME || 'wos-session';
         const nextCookies = await cookies();
 
-        nextCookies.set(cookieName, session, getCookieOptions(request.url) as CookieOptions);
+        nextCookies.set(cookieName, session, getCookieOptions(request.url));
 
         return response;
       } catch (error) {

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -1,18 +1,26 @@
 import { WORKOS_REDIRECT_URI, WORKOS_COOKIE_MAX_AGE, WORKOS_COOKIE_DOMAIN } from './env-variables.js';
 import { CookieOptions } from './interfaces.js';
 
-export function getCookieOptions(redirectUri?: string | null): CookieOptions {
+export function getCookieOptions(
+  redirectUri?: string | null,
+  asString: boolean = false,
+  expired: boolean = false,
+): CookieOptions | string {
   const url = new URL(redirectUri || WORKOS_REDIRECT_URI);
 
-  return {
-    path: '/',
-    httpOnly: true,
-    secure: url.protocol === 'https:',
-    sameSite: 'lax' as const,
-    // Defaults to 400 days, the maximum allowed by Chrome
-    // It's fine to have a long cookie expiry date as the access/refresh tokens
-    // act as the actual time-limited aspects of the session.
-    maxAge: WORKOS_COOKIE_MAX_AGE ? parseInt(WORKOS_COOKIE_MAX_AGE, 10) : 60 * 60 * 24 * 400,
-    domain: WORKOS_COOKIE_DOMAIN,
-  };
+  const maxAge = expired ? 0 : WORKOS_COOKIE_MAX_AGE ? parseInt(WORKOS_COOKIE_MAX_AGE, 10) : 60 * 60 * 24 * 400;
+
+  return asString
+    ? `Path=/; HttpOnly; Secure=${url.protocol === 'https:'}; SameSite="Lax"; Max-Age=${maxAge}; Domain=${WORKOS_COOKIE_DOMAIN || ''}`
+    : {
+        path: '/',
+        httpOnly: true,
+        secure: url.protocol === 'https:',
+        sameSite: 'lax' as const,
+        // Defaults to 400 days, the maximum allowed by Chrome
+        // It's fine to have a long cookie expiry date as the access/refresh tokens
+        // act as the actual time-limited aspects of the session.
+        maxAge,
+        domain: WORKOS_COOKIE_DOMAIN || '',
+      };
 }

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -1,6 +1,19 @@
 import { WORKOS_REDIRECT_URI, WORKOS_COOKIE_MAX_AGE, WORKOS_COOKIE_DOMAIN } from './env-variables.js';
 import { CookieOptions } from './interfaces.js';
 
+export function getCookieOptions(): CookieOptions;
+export function getCookieOptions(redirectUri?: string | null): CookieOptions;
+export function getCookieOptions(redirectUri: string | null | undefined, asString: true, expired?: boolean): string;
+export function getCookieOptions(
+  redirectUri: string | null | undefined,
+  asString: false,
+  expired?: boolean,
+): CookieOptions;
+export function getCookieOptions(
+  redirectUri?: string | null,
+  asString?: boolean,
+  expired?: boolean,
+): CookieOptions | string;
 export function getCookieOptions(
   redirectUri?: string | null,
   asString: boolean = false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from 'next/server';
 
-export function redirectWithFallback(redirectUri: string) {
+export function redirectWithFallback(redirectUri: string, headers?: Headers) {
+  const newHeaders = headers ? new Headers(headers) : new Headers();
+  newHeaders.set('Location', redirectUri);
+
   // Fall back to standard Response if NextResponse is not available.
   // This is to support Next.js 13.
   return NextResponse?.redirect
-    ? NextResponse.redirect(redirectUri)
-    : new Response(null, { status: 307, headers: { Location: redirectUri } });
+    ? NextResponse.redirect(redirectUri, { headers })
+    : new Response(null, { status: 307, headers: newHeaders });
 }
 
 export function errorResponseWithFallback(errorBody: { error: { message: string; description: string } }) {

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 
-export const VERSION = '1.0.0';
+export const VERSION = '1.0.1';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
Fixes https://github.com/workos/authkit-nextjs/issues/170

v1 shipped with bugs surrounding the refresh logic.

tl;dr is that we were using Next's `cookies()` helper method, which doesn't work in edge middleware. Instead we now set cookies via the headers. 

Want to release this as a fix as the general API is unchanged.