### PR TITLE
Fix server actions

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -21,8 +21,8 @@ export const getOrganizationAction = async (organizationId: string) => {
   return await workos.organizations.getOrganization(organizationId);
 };
 
-export const getAuthAction = async (ensureSignedIn?: boolean) => {
-  return await withAuth({ ensureSignedIn: ensureSignedIn as false });
+export const getAuthAction = async (options?: { ensureSignedIn?: boolean }) => {
+  return await withAuth(options);
 };
 
 export const refreshAuthAction = async ({

--- a/src/components/authkit-provider.tsx
+++ b/src/components/authkit-provider.tsx
@@ -42,7 +42,7 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
 
   const getAuth = async ({ ensureSignedIn = false }: { ensureSignedIn?: boolean } = {}) => {
     try {
-      const auth = await getAuthAction(ensureSignedIn);
+      const auth = await getAuthAction({ ensureSignedIn });
       setUser(auth.user);
       setSessionId(auth.sessionId);
       setOrganizationId(auth.organizationId);

--- a/src/session.ts
+++ b/src/session.ts
@@ -113,7 +113,10 @@ async function updateSession(
 ): Promise<AuthkitResponse> {
   const session = await getSessionFromCookie(request);
 
-  const newRequestHeaders = new Headers(request.headers);
+  // Since we're setting the headers in the response, we need to create a new Headers object without copying
+  // the request headers.
+  // See https://github.com/vercel/next.js/issues/50659#issuecomment-2333990159
+  const newRequestHeaders = new Headers();
 
   // Record that the request was routed through the middleware so we can check later for DX purposes
   newRequestHeaders.set(middlewareHeaderName, 'true');
@@ -348,9 +351,8 @@ async function redirectToSignIn() {
   redirect(await getAuthorizationUrl({ returnPathname, screenHint }));
 }
 
-async function withAuth(options?: { ensureSignedIn: false }): Promise<UserInfo | NoUserInfo>;
-async function withAuth(options: { ensureSignedIn: true }): Promise<UserInfo>;
-async function withAuth({ ensureSignedIn = false } = {}): Promise<UserInfo | NoUserInfo> {
+async function withAuth(options?: { ensureSignedIn?: boolean }): Promise<UserInfo | NoUserInfo>;
+async function withAuth({ ensureSignedIn = false }: { ensureSignedIn?: boolean } = {}): Promise<UserInfo | NoUserInfo> {
   const session = await getSessionFromHeader();
 
   if (!session) {


### PR DESCRIPTION
Fixes https://github.com/workos/authkit-nextjs/issues/175

We previously were copying headers from the request via `new Headers(request.headers)` which it turns out mangles the required headers for server actions.

This cleans up some types and makes sure we don't mess with the headers.

See this [issue](https://github.com/vercel/next.js/issues/50659#issuecomment-2333990159) for more details.