### PR TITLE
Bump to v1.0.2 and fix test

### DIFF
--- a/__tests__/authkit-provider.spec.tsx
+++ b/__tests__/authkit-provider.spec.tsx
@@ -188,7 +188,7 @@ describe('useAuth', () => {
 
     await waitFor(() => {
       expect(getAuthAction).toHaveBeenCalledTimes(2);
-      expect(getAuthAction).toHaveBeenLastCalledWith(true);
+      expect(getAuthAction).toHaveBeenLastCalledWith({ ensureSignedIn: true });
       expect(getByTestId('email')).toHaveTextContent('test@example.com');
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.17.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-nextjs",
-      "version": "0.17.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^7.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,7 +1,7 @@
 import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 
-export const VERSION = '1.0.1';
+export const VERSION = '1.0.2';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
v1.0.2 fixes an issue with Server Actions and the use of `ensureSignedIn` with `useAuth`.