### PR TITLE
Narrow withAuth type to User when ensureSignedIn is true

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -351,12 +351,13 @@ async function redirectToSignIn() {
   redirect(await getAuthorizationUrl({ returnPathname, screenHint }));
 }
 
-async function withAuth(options?: { ensureSignedIn?: boolean }): Promise<UserInfo | NoUserInfo>;
-async function withAuth({ ensureSignedIn = false }: { ensureSignedIn?: boolean } = {}): Promise<UserInfo | NoUserInfo> {
+async function withAuth(options: { ensureSignedIn: true }): Promise<UserInfo>;
+async function withAuth(options?: { ensureSignedIn?: true | false }): Promise<UserInfo | NoUserInfo>;
+async function withAuth(options?: { ensureSignedIn?: boolean }): Promise<UserInfo | NoUserInfo> {
   const session = await getSessionFromHeader();
 
   if (!session) {
-    if (ensureSignedIn) {
+    if (options?.ensureSignedIn) {
       await redirectToSignIn();
     }
     return { user: null };


### PR DESCRIPTION
When `ensureEignedIn` is true, the user will either be returned or next will throw a `NEXT_REDIRECT` to redirect to log in. This is described in #177.

```ts
const { user } = await withAuth(); // user is User or null

const { user } = await withAuth({ ensureSignedIn: false }); // user is User or null

const { user } = await withAuth({ ensureSignedIn: trie }); // user is User
```