### PR TITLE
Upgrade workos-node to v7.37.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@workos-inc/node": "^7.37.0",
+        "@workos-inc/node": "^7.37.1",
         "iron-session": "^8.0.1",
         "jose": "^5.2.3",
         "path-to-regexp": "^6.2.2"
@@ -2434,9 +2434,9 @@
       "dev": true
     },
     "node_modules/@workos-inc/node": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-7.37.0.tgz",
-      "integrity": "sha512-8RIPIlzKQjV848NdiTfEg3++iI0Z5zvt8ld3X3kUrIA0TuK0V/UVPR+Y4sz2cEtqxlz3eWAlqx8jwHrASxFb0w==",
+      "version": "7.37.1",
+      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-7.37.1.tgz",
+      "integrity": "sha512-/s7GwBH95ifEM1agWkt4QWpeMdn6HOkGqFl9liOZWiWqzyDrO3fCsSGXzXwx7amzkfbJ95+IAk8OzhVZ8BfMZg==",
       "dependencies": {
         "iron-session": "~6.3.1",
         "jose": "~5.6.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "format": "prettier \"{src,__tests__}/**/*.{js,ts,tsx}\" --write"
   },
   "dependencies": {
-    "@workos-inc/node": "^7.37.0",
+    "@workos-inc/node": "^7.37.1",
     "iron-session": "^8.0.1",
     "jose": "^5.2.3",
     "path-to-regexp": "^6.2.2"


### PR DESCRIPTION
v7.37.1 of workos-node fixes issue where worker code was importing Node's crypto library.

Fixes #187