### PR TITLE
Update Coana Guardrail

### DIFF
--- a/.github/workflows/coana-guardrail.yml
+++ b/.github/workflows/coana-guardrail.yml
@@ -12,44 +12,48 @@ jobs:
         uses: tj-actions/changed-files@v44
         with:
           separator: ' '
+ 
       - name: Checkout the ${{github.base_ref}} branch
         uses: actions/checkout@v4
         with:
-          ## checkout the base branch (usually master/main).
-          ref: ${{github.base_ref}}
+          ref: ${{github.base_ref}} # checkout the base branch (usually master/main).
+ 
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
+ 
       - name: Run Coana on the ${{github.base_ref}} branch
         run: |
           npx @coana-tech/cli run . \
-            --api-key ${{ secrets.COANA_API_KEY }} \
+            --guardrail-mode \
+            --api-key ${{ secrets.COANA_API_KEY || 'api-key-unavailable' }} \
             -o /tmp/main-branch \
-            --changed-files \
-            ${{ steps.changed-files.outputs.all_changed_files }} \
+            --changed-files ${{ steps.changed-files.outputs.all_changed_files }} \
             --lightweight-reachability \
-            --disable-report-submission \
-            --repo-url https://github.com/${{github.repository}}
+ 
+      # Reset file permissions changed by Coana CLI.
+      - name: Reset file permissions
+        run: sudo chown -R $USER:$USER .
+ 
       - name: Checkout the current branch
         uses: actions/checkout@v4
         with:
-          clean: false
+          clean: true
+ 
       - name: Run Coana on the current branch
         run: |
           npx @coana-tech/cli run . \
-            --api-key ${{ secrets.COANA_API_KEY }} \
+            --guardrail-mode \
+            --api-key ${{ secrets.COANA_API_KEY || 'api-key-unavailable' }} \
             -o /tmp/current-branch \
-            --changed-files \
-            ${{ steps.changed-files.outputs.all_changed_files }} \
+            --changed-files ${{ steps.changed-files.outputs.all_changed_files }} \
             --lightweight-reachability \
-            --disable-report-submission \
-            --repo-url https://github.com/${{github.repository}}
+ 
       - name: Run Report Comparison
         run: |
           npx @coana-tech/cli compare-reports \
-            --api-key ${{ secrets.COANA_API_KEY }} \
-            --no-block \
+            --api-key ${{ secrets.COANA_API_KEY || 'api-key-unavailable' }} \
             /tmp/main-branch/coana-report.json \
             /tmp/current-branch/coana-report.json
         env:


### PR DESCRIPTION
Update the Coana Guardrail to no longer require an API Key for PR scanning in public repositories.
This will allow contributors to have their PR code scanned for dependency vulnerabilities.