### PR TITLE
Add onError callback for customizing error handling in handleAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ export const GET = handleAUth({
 | `returnPathname` | `/`         | The pathname to redirect the user to after signing in                                                                                                                                                 |
 | `baseURL`        | `undefined` | The base URL to use for the redirect URI instead of the one in the request. Useful if the app is being run in a container like docker where the hostname can be different from the one in the request |
 | `onSuccess`      | `undefined` | A function that receives successful authentication data and can be used for side-effects like persisting tokens                                                                                       |
-| `onError` | `undefined` | A function that can receive the error and the request and handle the error in its own way.| 
+| `onError`        | `undefined` | A function that can receive the error and the request and handle the error in its own way.                                                                                                            |
 
 ### Middleware
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ export const GET = handleAUth({
 | `returnPathname` | `/`         | The pathname to redirect the user to after signing in                                                                                                                                                 |
 | `baseURL`        | `undefined` | The base URL to use for the redirect URI instead of the one in the request. Useful if the app is being run in a container like docker where the hostname can be different from the one in the request |
 | `onSuccess`      | `undefined` | A function that receives successful authentication data and can be used for side-effects like persisting tokens                                                                                       |
+| `resolveErrorResponse` | `undefined` | A function that can receive the error (or none if no `code` is found) and can be used to customize the error message and description. | 
 
 ### Middleware
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ export const GET = handleAUth({
 | `returnPathname` | `/`         | The pathname to redirect the user to after signing in                                                                                                                                                 |
 | `baseURL`        | `undefined` | The base URL to use for the redirect URI instead of the one in the request. Useful if the app is being run in a container like docker where the hostname can be different from the one in the request |
 | `onSuccess`      | `undefined` | A function that receives successful authentication data and can be used for side-effects like persisting tokens                                                                                       |
-| `resolveErrorResponse` | `undefined` | A function that can receive the error (or none if no `code` is found) and can be used to customize the error message and description. | 
+| `onError` | `undefined` | A function that can receive the error and the request and handle the error in its own way.| 
 
 ### Middleware
 

--- a/__tests__/authkit-callback-route.spec.ts
+++ b/__tests__/authkit-callback-route.spec.ts
@@ -107,16 +107,18 @@ describe('authkit-callback-route', () => {
       expect(data.error.message).toBe('Something went wrong');
     });
 
-    it('should handle authentication failure with custom error response', async () => {
+    it('should handle authentication failure with custom onError handler', async () => {
       // Mock authentication failure
       jest.mocked(workos.userManagement.authenticateWithCode).mockRejectedValue('Auth failed');
       request.nextUrl.searchParams.set('code', 'invalid-code');
 
       const handler = handleAuth({
-        resolveErrorResponse: (error) => ({
-          message: 'Custom error',
-          description: error?.toString() ?? 'No description',
-        }),
+        onError: ({ error }) => {
+          return new Response(JSON.stringify({ error: { message: 'Custom error' } }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        },
       });
       const response = await handler(request);
 

--- a/__tests__/authkit-callback-route.spec.ts
+++ b/__tests__/authkit-callback-route.spec.ts
@@ -107,6 +107,24 @@ describe('authkit-callback-route', () => {
       expect(data.error.message).toBe('Something went wrong');
     });
 
+    it('should handle authentication failure with custom error response', async () => {
+      // Mock authentication failure
+      jest.mocked(workos.userManagement.authenticateWithCode).mockRejectedValue('Auth failed');
+      request.nextUrl.searchParams.set('code', 'invalid-code');
+
+      const handler = handleAuth({
+        resolveErrorResponse: (error) => ({
+          message: 'Custom error',
+          description: error?.toString() ?? 'No description',
+        }),
+      });
+      const response = await handler(request);
+
+      expect(response.status).toBe(500);
+      const data = await response.json();
+      expect(data.error.message).toBe('Custom error');
+    });
+
     it('should handle missing code parameter', async () => {
       const handler = handleAuth();
       const response = await handler(request);

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -8,7 +8,7 @@ import { errorResponseWithFallback, redirectWithFallback } from './utils.js';
 import { workos } from './workos.js';
 
 export function handleAuth(options: HandleAuthOptions = {}) {
-  const { returnPathname: returnPathnameOption = '/', baseURL, onSuccess, resolveErrorResponse } = options;
+  const { returnPathname: returnPathnameOption = '/', baseURL, onSuccess, onError } = options;
 
   // Throw early if baseURL is provided but invalid
   if (baseURL) {
@@ -83,21 +83,23 @@ export function handleAuth(options: HandleAuthOptions = {}) {
 
         console.error(errorRes);
 
-        return errorResponse(error);
+        return errorResponse(request, error);
       }
     }
 
-    return errorResponse();
+    return errorResponse(request);
   };
 
-  function errorResponse(error?: unknown) {
-    const errorResponse = resolveErrorResponse?.(error) ?? {
-      message: 'Something went wrong',
-      description: "Couldn't sign in. If you are not sure what happened, please contact your organization admin.",
-    };
+  function errorResponse(request: NextRequest, error?: unknown) {
+    if (onError) {
+      return onError({ error, request });
+    }
 
     return errorResponseWithFallback({
-      error: errorResponse,
+      error: {
+        message: 'Something went wrong',
+        description: "Couldn't sign in. If you are not sure what happened, please contact your organization admin.",
+      },
     });
   }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,15 +1,11 @@
 import { OauthTokens, User } from '@workos-inc/node';
-
-export interface ErrorResponse {
-  message: string;
-  description: string;
-}
+import { type NextRequest } from 'next/server';
 
 export interface HandleAuthOptions {
   returnPathname?: string;
   baseURL?: string;
   onSuccess?: (data: HandleAuthSuccessData) => void | Promise<void>;
-  resolveErrorResponse?: (error?: unknown) => ErrorResponse;
+  onError?: (params: { error?: unknown; request: NextRequest }) => Response | Promise<Response>;
 }
 
 export interface HandleAuthSuccessData extends Session {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,9 +1,15 @@
 import { OauthTokens, User } from '@workos-inc/node';
 
+export interface ErrorResponse {
+  message: string;
+  description: string;
+}
+
 export interface HandleAuthOptions {
   returnPathname?: string;
   baseURL?: string;
   onSuccess?: (data: HandleAuthSuccessData) => void | Promise<void>;
+  resolveErrorResponse?: (error?: unknown) => ErrorResponse;
 }
 
 export interface HandleAuthSuccessData extends Session {


### PR DESCRIPTION
Add an optional `onError` callback that can be used to customize how errors are handled in `withAuth`.

```ts
import { handleAuth } from '@workos-inc/authkit-nextjs';

export const GET = handleAuth({
  onError: ({ error, request }) => {
    // do something with the error
    return NextResponse.redirect('/somewhere');
  }
});
```

Fixes #192 