### PR TITLE
Improve type safety for useAuth hook with ensureSignedIn

### DIFF
--- a/src/components/authkit-provider.tsx
+++ b/src/components/authkit-provider.tsx
@@ -166,6 +166,10 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
   );
 };
 
+export function useAuth(options: {
+  ensureSignedIn: true;
+}): AuthContextType & ({ loading: true; user: User | null } | { loading: false; user: User });
+export function useAuth(options?: { ensureSignedIn?: false }): AuthContextType;
 export function useAuth({ ensureSignedIn = false }: { ensureSignedIn?: boolean } = {}) {
   const context = useContext(AuthContext);
 


### PR DESCRIPTION
This PR improves the TypeScript type safety of the `useAuth` hook by adding function overloads that guarantee user data is available when `ensureSignedIn: true` is used.

### Changes
- Added function overloads for `useAuth` to provide stricter types
- When `ensureSignedIn: true` and `loading: false`, TypeScript now knows `user` is defined
- No runtime behavior changes, purely type-level improvements

### Example Usage
```typescript
// With ensureSignedIn: true
const auth = useAuth({ ensureSignedIn: true });
if (!auth.loading) {
  console.log(auth.user.email); // TypeScript knows user exists
}

// Without ensureSignedIn
const auth = useAuth();
if (!auth.loading && auth.user) {
  console.log(auth.user?.email); // Need to check for user
}
```

### Testing
- No runtime tests needed as this is a type-level change
- Verified TypeScript compiler accepts the new types
- Verified existing usage patterns still work