### PR TITLE
Lazy instantiate WorkOS instance on first use

### DIFF
--- a/__tests__/actions.spec.ts
+++ b/__tests__/actions.spec.ts
@@ -6,7 +6,7 @@ import {
   refreshAuthAction,
 } from '../src/actions.js';
 import { signOut } from '../src/auth.js';
-import { createWorkOSInstance } from '../src/workos.js';
+import { getWorkOSInstance } from '../src/workos.js';
 import { withAuth, refreshSession } from '../src/session.js';
 
 jest.mock('../src/auth.js', () => ({
@@ -19,7 +19,7 @@ const fakeWorkosInstance = {
   },
 };
 jest.mock('../src/workos.js', () => ({
-  createWorkOSInstance: jest.fn(() => fakeWorkosInstance),
+  getWorkOSInstance: jest.fn(() => fakeWorkosInstance),
 }));
 
 jest.mock('../src/session.js', () => ({
@@ -28,7 +28,7 @@ jest.mock('../src/session.js', () => ({
 }));
 
 describe('actions', () => {
-  const workos = createWorkOSInstance();
+  const workos = getWorkOSInstance();
   describe('checkSessionAction', () => {
     it('should return true for authenticated users', async () => {
       const result = await checkSessionAction();

--- a/__tests__/actions.spec.ts
+++ b/__tests__/actions.spec.ts
@@ -6,7 +6,7 @@ import {
   refreshAuthAction,
 } from '../src/actions.js';
 import { signOut } from '../src/auth.js';
-import { getWorkOSInstance } from '../src/workos.js';
+import { getWorkOS } from '../src/workos.js';
 import { withAuth, refreshSession } from '../src/session.js';
 
 jest.mock('../src/auth.js', () => ({
@@ -19,7 +19,7 @@ const fakeWorkosInstance = {
   },
 };
 jest.mock('../src/workos.js', () => ({
-  getWorkOSInstance: jest.fn(() => fakeWorkosInstance),
+  getWorkOS: jest.fn(() => fakeWorkosInstance),
 }));
 
 jest.mock('../src/session.js', () => ({
@@ -28,7 +28,7 @@ jest.mock('../src/session.js', () => ({
 }));
 
 describe('actions', () => {
-  const workos = getWorkOSInstance();
+  const workos = getWorkOS();
   describe('checkSessionAction', () => {
     it('should return true for authenticated users', async () => {
       const result = await checkSessionAction();

--- a/__tests__/actions.spec.ts
+++ b/__tests__/actions.spec.ts
@@ -6,19 +6,20 @@ import {
   refreshAuthAction,
 } from '../src/actions.js';
 import { signOut } from '../src/auth.js';
-import { workos } from '../src/workos.js';
+import { createWorkOSInstance } from '../src/workos.js';
 import { withAuth, refreshSession } from '../src/session.js';
 
 jest.mock('../src/auth.js', () => ({
   signOut: jest.fn().mockResolvedValue(true),
 }));
 
-jest.mock('../src/workos.js', () => ({
-  workos: {
-    organizations: {
-      getOrganization: jest.fn().mockResolvedValue({ id: 'org_123', name: 'Test Org' }),
-    },
+const fakeWorkosInstance = {
+  organizations: {
+    getOrganization: jest.fn().mockResolvedValue({ id: 'org_123', name: 'Test Org' }),
   },
+};
+jest.mock('../src/workos.js', () => ({
+  createWorkOSInstance: jest.fn(() => fakeWorkosInstance),
 }));
 
 jest.mock('../src/session.js', () => ({
@@ -27,6 +28,7 @@ jest.mock('../src/session.js', () => ({
 }));
 
 describe('actions', () => {
+  const workos = createWorkOSInstance();
   describe('checkSessionAction', () => {
     it('should return true for authenticated users', async () => {
       const result = await checkSessionAction();

--- a/__tests__/authkit-callback-route.spec.ts
+++ b/__tests__/authkit-callback-route.spec.ts
@@ -1,4 +1,4 @@
-import { getWorkOSInstance } from '../src/workos.js';
+import { getWorkOS } from '../src/workos.js';
 import { handleAuth } from '../src/authkit-callback-route.js';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -14,11 +14,11 @@ const fakeWorkosInstance = {
 };
 
 jest.mock('../src/workos', () => ({
-  getWorkOSInstance: jest.fn(() => fakeWorkosInstance),
+  getWorkOS: jest.fn(() => fakeWorkosInstance),
 }));
 
 describe('authkit-callback-route', () => {
-  const workos = getWorkOSInstance();
+  const workos = getWorkOS();
   const mockAuthResponse = {
     accessToken: 'access123',
     refreshToken: 'refresh123',

--- a/__tests__/authkit-callback-route.spec.ts
+++ b/__tests__/authkit-callback-route.spec.ts
@@ -1,4 +1,4 @@
-import { workos } from '../src/workos.js';
+import { createWorkOSInstance } from '../src/workos.js';
 import { handleAuth } from '../src/authkit-callback-route.js';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -6,16 +6,19 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies, headers } from 'next/headers';
 
 // Mock dependencies
-jest.mock('../src/workos', () => ({
-  workos: {
-    userManagement: {
-      authenticateWithCode: jest.fn(),
-      getJwksUrl: jest.fn(() => 'https://api.workos.com/sso/jwks/client_1234567890'),
-    },
+const fakeWorkosInstance = {
+  userManagement: {
+    authenticateWithCode: jest.fn(),
+    getJwksUrl: jest.fn(() => 'https://api.workos.com/sso/jwks/client_1234567890'),
   },
+};
+
+jest.mock('../src/workos', () => ({
+  createWorkOSInstance: jest.fn(() => fakeWorkosInstance),
 }));
 
 describe('authkit-callback-route', () => {
+  const workos = createWorkOSInstance();
   const mockAuthResponse = {
     accessToken: 'access123',
     refreshToken: 'refresh123',

--- a/__tests__/authkit-callback-route.spec.ts
+++ b/__tests__/authkit-callback-route.spec.ts
@@ -1,4 +1,4 @@
-import { createWorkOSInstance } from '../src/workos.js';
+import { getWorkOSInstance } from '../src/workos.js';
 import { handleAuth } from '../src/authkit-callback-route.js';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -14,11 +14,11 @@ const fakeWorkosInstance = {
 };
 
 jest.mock('../src/workos', () => ({
-  createWorkOSInstance: jest.fn(() => fakeWorkosInstance),
+  getWorkOSInstance: jest.fn(() => fakeWorkosInstance),
 }));
 
 describe('authkit-callback-route', () => {
-  const workos = createWorkOSInstance();
+  const workos = getWorkOSInstance();
   const mockAuthResponse = {
     accessToken: 'access123',
     refreshToken: 'refresh123',

--- a/__tests__/get-authorization-url.spec.ts
+++ b/__tests__/get-authorization-url.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { getAuthorizationUrl } from '../src/get-authorization-url.js';
 import { headers } from 'next/headers';
-import { getWorkOSInstance } from '../src/workos.js';
+import { getWorkOS } from '../src/workos.js';
 
 jest.mock('next/headers');
 
@@ -13,11 +13,11 @@ const fakeWorkosInstance = {
 };
 
 jest.mock('../src/workos', () => ({
-  getWorkOSInstance: jest.fn(() => fakeWorkosInstance),
+  getWorkOS: jest.fn(() => fakeWorkosInstance),
 }));
 
 describe('getAuthorizationUrl', () => {
-  const workos = getWorkOSInstance();
+  const workos = getWorkOS();
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/__tests__/get-authorization-url.spec.ts
+++ b/__tests__/get-authorization-url.spec.ts
@@ -1,12 +1,23 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { getAuthorizationUrl } from '../src/get-authorization-url.js';
 import { headers } from 'next/headers';
-import { workos } from '../src/workos.js';
+import { createWorkOSInstance } from '../src/workos.js';
 
 jest.mock('next/headers');
-jest.mock('../src/workos.js');
+
+// Mock dependencies
+const fakeWorkosInstance = {
+  userManagement: {
+    getAuthorizationUrl: jest.fn(),
+  },
+};
+
+jest.mock('../src/workos', () => ({
+  createWorkOSInstance: jest.fn(() => fakeWorkosInstance),
+}));
 
 describe('getAuthorizationUrl', () => {
+  const workos = createWorkOSInstance();
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/__tests__/get-authorization-url.spec.ts
+++ b/__tests__/get-authorization-url.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { getAuthorizationUrl } from '../src/get-authorization-url.js';
 import { headers } from 'next/headers';
-import { createWorkOSInstance } from '../src/workos.js';
+import { getWorkOSInstance } from '../src/workos.js';
 
 jest.mock('next/headers');
 
@@ -13,11 +13,11 @@ const fakeWorkosInstance = {
 };
 
 jest.mock('../src/workos', () => ({
-  createWorkOSInstance: jest.fn(() => fakeWorkosInstance),
+  getWorkOSInstance: jest.fn(() => fakeWorkosInstance),
 }));
 
 describe('getAuthorizationUrl', () => {
-  const workos = createWorkOSInstance();
+  const workos = getWorkOSInstance();
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/__tests__/session.spec.ts
+++ b/__tests__/session.spec.ts
@@ -3,7 +3,7 @@ import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { generateTestToken } from './test-helpers.js';
 import { withAuth, updateSession, refreshSession, terminateSession, updateSessionMiddleware } from '../src/session.js';
-import { getWorkOSInstance } from '../src/workos.js';
+import { getWorkOS } from '../src/workos.js';
 import * as envVariables from '../src/env-variables.js';
 
 import { jwtVerify } from 'jose';
@@ -20,7 +20,7 @@ jest.mock('jose', () => ({
 // logging is disabled by default, flip this to true to still have logs in the console
 const DEBUG = false;
 
-const workos = getWorkOSInstance();
+const workos = getWorkOS();
 
 describe('session.ts', () => {
   const mockSession = {

--- a/__tests__/session.spec.ts
+++ b/__tests__/session.spec.ts
@@ -3,7 +3,7 @@ import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { generateTestToken } from './test-helpers.js';
 import { withAuth, updateSession, refreshSession, terminateSession, updateSessionMiddleware } from '../src/session.js';
-import { workos } from '../src/workos.js';
+import { createWorkOSInstance } from '../src/workos.js';
 import * as envVariables from '../src/env-variables.js';
 
 import { jwtVerify } from 'jose';
@@ -19,6 +19,8 @@ jest.mock('jose', () => ({
 
 // logging is disabled by default, flip this to true to still have logs in the console
 const DEBUG = false;
+
+const workos = createWorkOSInstance();
 
 describe('session.ts', () => {
   const mockSession = {

--- a/__tests__/session.spec.ts
+++ b/__tests__/session.spec.ts
@@ -3,7 +3,7 @@ import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { generateTestToken } from './test-helpers.js';
 import { withAuth, updateSession, refreshSession, terminateSession, updateSessionMiddleware } from '../src/session.js';
-import { createWorkOSInstance } from '../src/workos.js';
+import { getWorkOSInstance } from '../src/workos.js';
 import * as envVariables from '../src/env-variables.js';
 
 import { jwtVerify } from 'jose';
@@ -20,7 +20,7 @@ jest.mock('jose', () => ({
 // logging is disabled by default, flip this to true to still have logs in the console
 const DEBUG = false;
 
-const workos = createWorkOSInstance();
+const workos = getWorkOSInstance();
 
 describe('session.ts', () => {
   const mockSession = {

--- a/__tests__/workos.spec.ts
+++ b/__tests__/workos.spec.ts
@@ -1,7 +1,8 @@
 import { WorkOS } from '@workos-inc/node';
-import { workos, VERSION } from '../src/workos.js';
+import { createWorkOSInstance, VERSION } from '../src/workos.js';
 
 describe('workos', () => {
+  const workos = createWorkOSInstance();
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -44,23 +45,23 @@ describe('workos', () => {
 
     it('uses custom API hostname when provided', async () => {
       process.env.WORKOS_API_HOSTNAME = 'custom.workos.com';
-      const { workos: customWorkos } = await import('../src/workos.js');
+      const { createWorkOSInstance: customWorkos } = await import('../src/workos.js');
 
-      expect(customWorkos.options.apiHostname).toEqual('custom.workos.com');
+      expect(customWorkos().options.apiHostname).toEqual('custom.workos.com');
     });
 
     it('uses custom HTTPS setting when provided', async () => {
       process.env.WORKOS_API_HTTPS = 'false';
-      const { workos: customWorkos } = await import('../src/workos.js');
+      const { createWorkOSInstance: customWorkos } = await import('../src/workos.js');
 
-      expect(customWorkos.options.https).toEqual(false);
+      expect(customWorkos().options.https).toEqual(false);
     });
 
     it('uses custom port when provided', async () => {
       process.env.WORKOS_API_PORT = '8080';
-      const { workos: customWorkos } = await import('../src/workos.js');
+      const { createWorkOSInstance: customWorkos } = await import('../src/workos.js');
 
-      expect(customWorkos.options.port).toEqual(8080);
+      expect(customWorkos().options.port).toEqual(8080);
     });
   });
 });

--- a/__tests__/workos.spec.ts
+++ b/__tests__/workos.spec.ts
@@ -1,8 +1,8 @@
 import { WorkOS } from '@workos-inc/node';
-import { getWorkOSInstance, VERSION } from '../src/workos.js';
+import { getWorkOS, VERSION } from '../src/workos.js';
 
 describe('workos', () => {
-  const workos = getWorkOSInstance();
+  const workos = getWorkOS();
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -45,21 +45,21 @@ describe('workos', () => {
 
     it('uses custom API hostname when provided', async () => {
       process.env.WORKOS_API_HOSTNAME = 'custom.workos.com';
-      const { getWorkOSInstance: customWorkos } = await import('../src/workos.js');
+      const { getWorkOS: customWorkos } = await import('../src/workos.js');
 
       expect(customWorkos().options.apiHostname).toEqual('custom.workos.com');
     });
 
     it('uses custom HTTPS setting when provided', async () => {
       process.env.WORKOS_API_HTTPS = 'false';
-      const { getWorkOSInstance: customWorkos } = await import('../src/workos.js');
+      const { getWorkOS: customWorkos } = await import('../src/workos.js');
 
       expect(customWorkos().options.https).toEqual(false);
     });
 
     it('uses custom port when provided', async () => {
       process.env.WORKOS_API_PORT = '8080';
-      const { getWorkOSInstance: customWorkos } = await import('../src/workos.js');
+      const { getWorkOS: customWorkos } = await import('../src/workos.js');
 
       expect(customWorkos().options.port).toEqual(8080);
     });

--- a/__tests__/workos.spec.ts
+++ b/__tests__/workos.spec.ts
@@ -1,8 +1,8 @@
 import { WorkOS } from '@workos-inc/node';
-import { createWorkOSInstance, VERSION } from '../src/workos.js';
+import { getWorkOSInstance, VERSION } from '../src/workos.js';
 
 describe('workos', () => {
-  const workos = createWorkOSInstance();
+  const workos = getWorkOSInstance();
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -45,21 +45,21 @@ describe('workos', () => {
 
     it('uses custom API hostname when provided', async () => {
       process.env.WORKOS_API_HOSTNAME = 'custom.workos.com';
-      const { createWorkOSInstance: customWorkos } = await import('../src/workos.js');
+      const { getWorkOSInstance: customWorkos } = await import('../src/workos.js');
 
       expect(customWorkos().options.apiHostname).toEqual('custom.workos.com');
     });
 
     it('uses custom HTTPS setting when provided', async () => {
       process.env.WORKOS_API_HTTPS = 'false';
-      const { createWorkOSInstance: customWorkos } = await import('../src/workos.js');
+      const { getWorkOSInstance: customWorkos } = await import('../src/workos.js');
 
       expect(customWorkos().options.https).toEqual(false);
     });
 
     it('uses custom port when provided', async () => {
       process.env.WORKOS_API_PORT = '8080';
-      const { createWorkOSInstance: customWorkos } = await import('../src/workos.js');
+      const { getWorkOSInstance: customWorkos } = await import('../src/workos.js');
 
       expect(customWorkos().options.port).toEqual(8080);
     });

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,7 +2,7 @@
 
 import { signOut } from './auth.js';
 import { refreshSession, withAuth } from './session.js';
-import { getWorkOSInstance } from './workos.js';
+import { getWorkOS } from './workos.js';
 
 /**
  * This action is only accessible to authenticated users,
@@ -18,7 +18,7 @@ export const handleSignOutAction = async ({ returnTo }: { returnTo?: string } = 
 };
 
 export const getOrganizationAction = async (organizationId: string) => {
-  return await getWorkOSInstance().organizations.getOrganization(organizationId);
+  return await getWorkOS().organizations.getOrganization(organizationId);
 };
 
 export const getAuthAction = async (options?: { ensureSignedIn?: boolean }) => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,7 +2,7 @@
 
 import { signOut } from './auth.js';
 import { refreshSession, withAuth } from './session.js';
-import { workos } from './workos.js';
+import { createWorkOSInstance } from './workos.js';
 
 /**
  * This action is only accessible to authenticated users,
@@ -18,7 +18,7 @@ export const handleSignOutAction = async ({ returnTo }: { returnTo?: string } = 
 };
 
 export const getOrganizationAction = async (organizationId: string) => {
-  return await workos.organizations.getOrganization(organizationId);
+  return await createWorkOSInstance().organizations.getOrganization(organizationId);
 };
 
 export const getAuthAction = async (options?: { ensureSignedIn?: boolean }) => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,7 +2,7 @@
 
 import { signOut } from './auth.js';
 import { refreshSession, withAuth } from './session.js';
-import { createWorkOSInstance } from './workos.js';
+import { getWorkOSInstance } from './workos.js';
 
 /**
  * This action is only accessible to authenticated users,
@@ -18,7 +18,7 @@ export const handleSignOutAction = async ({ returnTo }: { returnTo?: string } = 
 };
 
 export const getOrganizationAction = async (organizationId: string) => {
-  return await createWorkOSInstance().organizations.getOrganization(organizationId);
+  return await getWorkOSInstance().organizations.getOrganization(organizationId);
 };
 
 export const getAuthAction = async (options?: { ensureSignedIn?: boolean }) => {

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -5,7 +5,7 @@ import { WORKOS_CLIENT_ID, WORKOS_COOKIE_NAME } from './env-variables.js';
 import { HandleAuthOptions } from './interfaces.js';
 import { encryptSession } from './session.js';
 import { errorResponseWithFallback, redirectWithFallback } from './utils.js';
-import { workos } from './workos.js';
+import { createWorkOSInstance } from './workos.js';
 
 export function handleAuth(options: HandleAuthOptions = {}) {
   const { returnPathname: returnPathnameOption = '/', baseURL, onSuccess, onError } = options;
@@ -28,7 +28,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
       try {
         // Use the code returned to us by AuthKit and authenticate the user with WorkOS
         const { accessToken, refreshToken, user, impersonator, oauthTokens } =
-          await workos.userManagement.authenticateWithCode({
+          await createWorkOSInstance().userManagement.authenticateWithCode({
             clientId: WORKOS_CLIENT_ID,
             code,
           });

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -5,7 +5,7 @@ import { WORKOS_CLIENT_ID, WORKOS_COOKIE_NAME } from './env-variables.js';
 import { HandleAuthOptions } from './interfaces.js';
 import { encryptSession } from './session.js';
 import { errorResponseWithFallback, redirectWithFallback } from './utils.js';
-import { getWorkOSInstance } from './workos.js';
+import { getWorkOS } from './workos.js';
 
 export function handleAuth(options: HandleAuthOptions = {}) {
   const { returnPathname: returnPathnameOption = '/', baseURL, onSuccess, onError } = options;
@@ -28,7 +28,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
       try {
         // Use the code returned to us by AuthKit and authenticate the user with WorkOS
         const { accessToken, refreshToken, user, impersonator, oauthTokens } =
-          await getWorkOSInstance().userManagement.authenticateWithCode({
+          await getWorkOS().userManagement.authenticateWithCode({
             clientId: WORKOS_CLIENT_ID,
             code,
           });

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -5,7 +5,7 @@ import { WORKOS_CLIENT_ID, WORKOS_COOKIE_NAME } from './env-variables.js';
 import { HandleAuthOptions } from './interfaces.js';
 import { encryptSession } from './session.js';
 import { errorResponseWithFallback, redirectWithFallback } from './utils.js';
-import { createWorkOSInstance } from './workos.js';
+import { getWorkOSInstance } from './workos.js';
 
 export function handleAuth(options: HandleAuthOptions = {}) {
   const { returnPathname: returnPathnameOption = '/', baseURL, onSuccess, onError } = options;
@@ -28,7 +28,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
       try {
         // Use the code returned to us by AuthKit and authenticate the user with WorkOS
         const { accessToken, refreshToken, user, impersonator, oauthTokens } =
-          await createWorkOSInstance().userManagement.authenticateWithCode({
+          await getWorkOSInstance().userManagement.authenticateWithCode({
             clientId: WORKOS_CLIENT_ID,
             code,
           });

--- a/src/get-authorization-url.ts
+++ b/src/get-authorization-url.ts
@@ -1,4 +1,4 @@
-import { createWorkOSInstance } from './workos.js';
+import { getWorkOSInstance } from './workos.js';
 import { WORKOS_CLIENT_ID, WORKOS_REDIRECT_URI } from './env-variables.js';
 import { GetAuthURLOptions } from './interfaces.js';
 import { headers } from 'next/headers';
@@ -7,7 +7,7 @@ async function getAuthorizationUrl(options: GetAuthURLOptions = {}) {
   const headersList = await headers();
   const { returnPathname, screenHint, organizationId, redirectUri = headersList.get('x-redirect-uri') } = options;
 
-  return createWorkOSInstance().userManagement.getAuthorizationUrl({
+  return getWorkOSInstance().userManagement.getAuthorizationUrl({
     provider: 'authkit',
     clientId: WORKOS_CLIENT_ID,
     redirectUri: redirectUri ?? WORKOS_REDIRECT_URI,

--- a/src/get-authorization-url.ts
+++ b/src/get-authorization-url.ts
@@ -1,4 +1,4 @@
-import { workos } from './workos.js';
+import { createWorkOSInstance } from './workos.js';
 import { WORKOS_CLIENT_ID, WORKOS_REDIRECT_URI } from './env-variables.js';
 import { GetAuthURLOptions } from './interfaces.js';
 import { headers } from 'next/headers';
@@ -7,7 +7,7 @@ async function getAuthorizationUrl(options: GetAuthURLOptions = {}) {
   const headersList = await headers();
   const { returnPathname, screenHint, organizationId, redirectUri = headersList.get('x-redirect-uri') } = options;
 
-  return workos.userManagement.getAuthorizationUrl({
+  return createWorkOSInstance().userManagement.getAuthorizationUrl({
     provider: 'authkit',
     clientId: WORKOS_CLIENT_ID,
     redirectUri: redirectUri ?? WORKOS_REDIRECT_URI,

--- a/src/get-authorization-url.ts
+++ b/src/get-authorization-url.ts
@@ -1,4 +1,4 @@
-import { getWorkOSInstance } from './workos.js';
+import { getWorkOS } from './workos.js';
 import { WORKOS_CLIENT_ID, WORKOS_REDIRECT_URI } from './env-variables.js';
 import { GetAuthURLOptions } from './interfaces.js';
 import { headers } from 'next/headers';
@@ -7,7 +7,7 @@ async function getAuthorizationUrl(options: GetAuthURLOptions = {}) {
   const headersList = await headers();
   const { returnPathname, screenHint, organizationId, redirectUri = headersList.get('x-redirect-uri') } = options;
 
-  return getWorkOSInstance().userManagement.getAuthorizationUrl({
+  return getWorkOS().userManagement.getAuthorizationUrl({
     provider: 'authkit',
     clientId: WORKOS_CLIENT_ID,
     redirectUri: redirectUri ?? WORKOS_REDIRECT_URI,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { OauthTokens, User } from '@workos-inc/node';
+import type { OauthTokens, User } from '@workos-inc/node';
 import { type NextRequest } from 'next/server';
 
 export interface HandleAuthOptions {

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { jwtVerify, createRemoteJWKSet, decodeJwt } from 'jose';
 import { sealData, unsealData } from 'iron-session';
 import { getCookieOptions } from './cookie.js';
-import { getWorkOSInstance } from './workos.js';
+import { getWorkOS } from './workos.js';
 import { WORKOS_CLIENT_ID, WORKOS_COOKIE_PASSWORD, WORKOS_COOKIE_NAME, WORKOS_REDIRECT_URI } from './env-variables.js';
 import { getAuthorizationUrl } from './get-authorization-url.js';
 import {
@@ -27,7 +27,7 @@ const sessionHeaderName = 'x-workos-session';
 const middlewareHeaderName = 'x-workos-middleware';
 const signUpPathsHeaderName = 'x-sign-up-paths';
 
-const JWKS = lazy(() => createRemoteJWKSet(new URL(getWorkOSInstance().userManagement.getJwksUrl(WORKOS_CLIENT_ID))));
+const JWKS = lazy(() => createRemoteJWKSet(new URL(getWorkOS().userManagement.getJwksUrl(WORKOS_CLIENT_ID))));
 
 async function encryptSession(session: Session) {
   return sealData(session, {
@@ -185,7 +185,7 @@ async function updateSession(
     const { org_id: organizationIdFromAccessToken } = decodeJwt<AccessToken>(session.accessToken);
 
     const { accessToken, refreshToken, user, impersonator } =
-      await getWorkOSInstance().userManagement.authenticateWithRefreshToken({
+      await getWorkOS().userManagement.authenticateWithRefreshToken({
         clientId: WORKOS_CLIENT_ID,
         refreshToken: session.refreshToken,
         organizationId: organizationIdFromAccessToken,
@@ -271,7 +271,7 @@ async function refreshSession({
   let refreshResult;
 
   try {
-    refreshResult = await getWorkOSInstance().userManagement.authenticateWithRefreshToken({
+    refreshResult = await getWorkOS().userManagement.authenticateWithRefreshToken({
       clientId: WORKOS_CLIENT_ID,
       refreshToken: session.refreshToken,
       organizationId: nextOrganizationId ?? organizationIdFromAccessToken,
@@ -390,7 +390,7 @@ async function withAuth(options?: { ensureSignedIn?: boolean }): Promise<UserInf
 async function terminateSession({ returnTo }: { returnTo?: string } = {}) {
   const { sessionId } = await withAuth();
   if (sessionId) {
-    redirect(getWorkOSInstance().userManagement.getLogoutUrl({ sessionId, returnTo }));
+    redirect(getWorkOS().userManagement.getLogoutUrl({ sessionId, returnTo }));
   } else {
     redirect(returnTo ?? '/');
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,7 +6,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { jwtVerify, createRemoteJWKSet, decodeJwt } from 'jose';
 import { sealData, unsealData } from 'iron-session';
 import { getCookieOptions } from './cookie.js';
-import { createWorkOSInstance } from './workos.js';
+import { getWorkOSInstance } from './workos.js';
 import { WORKOS_CLIENT_ID, WORKOS_COOKIE_PASSWORD, WORKOS_COOKIE_NAME, WORKOS_REDIRECT_URI } from './env-variables.js';
 import { getAuthorizationUrl } from './get-authorization-url.js';
 import {
@@ -27,9 +27,7 @@ const sessionHeaderName = 'x-workos-session';
 const middlewareHeaderName = 'x-workos-middleware';
 const signUpPathsHeaderName = 'x-sign-up-paths';
 
-const JWKS = lazy(() =>
-  createRemoteJWKSet(new URL(createWorkOSInstance().userManagement.getJwksUrl(WORKOS_CLIENT_ID))),
-);
+const JWKS = lazy(() => createRemoteJWKSet(new URL(getWorkOSInstance().userManagement.getJwksUrl(WORKOS_CLIENT_ID))));
 
 async function encryptSession(session: Session) {
   return sealData(session, {
@@ -187,7 +185,7 @@ async function updateSession(
     const { org_id: organizationIdFromAccessToken } = decodeJwt<AccessToken>(session.accessToken);
 
     const { accessToken, refreshToken, user, impersonator } =
-      await createWorkOSInstance().userManagement.authenticateWithRefreshToken({
+      await getWorkOSInstance().userManagement.authenticateWithRefreshToken({
         clientId: WORKOS_CLIENT_ID,
         refreshToken: session.refreshToken,
         organizationId: organizationIdFromAccessToken,
@@ -273,7 +271,7 @@ async function refreshSession({
   let refreshResult;
 
   try {
-    refreshResult = await createWorkOSInstance().userManagement.authenticateWithRefreshToken({
+    refreshResult = await getWorkOSInstance().userManagement.authenticateWithRefreshToken({
       clientId: WORKOS_CLIENT_ID,
       refreshToken: session.refreshToken,
       organizationId: nextOrganizationId ?? organizationIdFromAccessToken,
@@ -392,7 +390,7 @@ async function withAuth(options?: { ensureSignedIn?: boolean }): Promise<UserInf
 async function terminateSession({ returnTo }: { returnTo?: string } = {}) {
   const { sessionId } = await withAuth();
   if (sessionId) {
-    redirect(createWorkOSInstance().userManagement.getLogoutUrl({ sessionId, returnTo }));
+    redirect(getWorkOSInstance().userManagement.getLogoutUrl({ sessionId, returnTo }));
   } else {
     redirect(returnTo ?? '/');
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,3 +21,22 @@ export function errorResponseWithFallback(errorBody: { error: { message: string;
         headers: { 'Content-Type': 'application/json' },
       });
 }
+
+/**
+ * Returns a function that can only be called once.
+ * Subsequent calls will return the result of the first call.
+ * This is useful for lazy initialization.
+ * @param fn - The function to be called once.
+ * @returns A function that can only be called once.
+ */
+export function lazy<T>(fn: () => T): () => T {
+  let called = false;
+  let result: T;
+  return () => {
+    if (!called) {
+      result = fn();
+      called = true;
+    }
+    return result;
+  };
+}

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -19,4 +19,4 @@ const options = {
  * If an instance already exists, it returns the existing instance.
  * @returns The WorkOS instance.
  */
-export const getWorkOSInstance = lazy(() => new WorkOS(WORKOS_API_KEY, options));
+export const getWorkOS = lazy(() => new WorkOS(WORKOS_API_KEY, options));

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -1,5 +1,6 @@
 import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
+import { lazy } from './utils.js';
 
 export const VERSION = '1.4.0';
 
@@ -13,7 +14,9 @@ const options = {
   },
 };
 
-// Initialize the WorkOS client
-const workos = new WorkOS(WORKOS_API_KEY, options);
-
-export { workos };
+/**
+ * Create a WorkOS instance with the provided API key and options.
+ * If an instance already exists, it returns the existing instance.
+ * @returns The WorkOS instance.
+ */
+export const createWorkOSInstance = lazy(() => new WorkOS(WORKOS_API_KEY, options));

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -19,4 +19,4 @@ const options = {
  * If an instance already exists, it returns the existing instance.
  * @returns The WorkOS instance.
  */
-export const createWorkOSInstance = lazy(() => new WorkOS(WORKOS_API_KEY, options));
+export const getWorkOSInstance = lazy(() => new WorkOS(WORKOS_API_KEY, options));


### PR DESCRIPTION
Refactor WorkOS client instantiation to use a lazy initialization pattern via
a new `createWorkOSInstance()` helper. The instance is now created only when
first accessed, avoiding issues where missing environment variables cause build errors.

- Introduce a `lazy` helper to defer instantiation.
- Replace direct `workos` imports with `createWorkOSInstance()`.
- Update tests to use a shared fake instance for reliable mocks.

fixes #200