### PR TITLE
Fix debug error message when session token is missing

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -174,11 +174,14 @@ async function updateSession(
     };
   }
 
-  if (options.debug) {
-    console.log(`Session invalid. Refreshing access token that ends in ${session.accessToken.slice(-10)}`);
-  }
-
   try {
+    if (options.debug) {
+      // istanbul ignore next
+      console.log(
+        `Session invalid. ${session.accessToken ? `Refreshing access token that ends in ${session.accessToken.slice(-10)}` : 'Access token missing.'}`,
+      );
+    }
+
     const { org_id: organizationIdFromAccessToken } = decodeJwt<AccessToken>(session.accessToken);
 
     const { accessToken, refreshToken, user, impersonator } = await workos.userManagement.authenticateWithRefreshToken({


### PR DESCRIPTION
This PR fixes an issue where the debug message would throw an error if the session token could not be found. Previously, the debug log attempted to slice the accessToken, which could be undefined, causing a runtime error.

To resolve this, the debug message now checks for the presence of session.accessToken before slicing. If the token is missing, it logs a different message instead.

Changes:
	•	Moved the debug log inside the try block to prevent potential errors.
	•	Updated the log message to conditionally handle missing access tokens.
	•	Added istanbul ignore next to exclude the debug log from test coverage.

Testing:
	•	Verified that the debug message no longer throws an error when the session token is missing.
	•	Ensured the log correctly prints either the token suffix or a fallback message.

Fixes #202 