### PR TITLE
Expose WorkOS client for advanced use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,22 @@ export default authkitMiddleware({
 });
 ```
 
+### Advanced: Direct access to the WorkOS client
+
+For advanced use cases or functionality not covered by the helper methods, you can access the underlying WorkOS client directly:
+
+```typescript
+import { getWorkOS } from '@workos-inc/authkit-nextjs';
+
+// Get the configured WorkOS client instance
+const workos = getWorkOS();
+
+// Use any WorkOS SDK method
+const organizations = await workos.organizations.listOrganizations({
+  limit: 10,
+});
+````
+
 ### Debugging
 
 To enable debug logs, initialize the middleware with the debug flag enabled.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,12 @@ import { handleAuth } from './authkit-callback-route.js';
 import { authkit, authkitMiddleware } from './middleware.js';
 import { withAuth, refreshSession } from './session.js';
 import { getSignInUrl, getSignUpUrl, signOut } from './auth.js';
+import { getWorkOS } from './workos.js';
 
 export * from './interfaces.js';
 
 export {
+  getWorkOS,
   handleAuth,
   //
   authkitMiddleware,


### PR DESCRIPTION
This PR adds the ability to access the underlying WorkOS client directly for advanced use cases that are not covered by existing helper methods.

**Changes:**

- Updated README.md:
    - Added a new “Advanced: Direct access to the WorkOS client” section.
    - Provided an example of how to retrieve and use the WorkOS client via getWorkOS().
- Exported `getWorkOS` to allow direct access to the WorkOS client.

**Why?**

This change enables developers to use lower-level WorkOS SDK methods when necessary, without being restricted to the helper methods provided by the library.

Testing:
- Verified that `getWorkOS()` successfully returns the WorkOS client instance.
- Ensured existing functionality remains unaffected.