### PR TITLE
v1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-nextjs",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^7.37.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -2,7 +2,7 @@ import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 import { lazy } from './utils.js';
 
-export const VERSION = '1.4.0';
+export const VERSION = '1.4.1';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
This pull request includes a version bump for the `@workos-inc/authkit-nextjs` package from `1.4.0` to `1.4.1`.

Version bump:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `1.4.0` to `1.4.1`.
* [`src/workos.ts`](diffhunk://#diff-43fae42284da1898f98b43b56a7bc6f5fb979e271bca59f4670751ba2c0020efL5-R5): Updated the `VERSION` constant from `1.4.0` to `1.4.1`.