### PR TITLE
remove accessToken from being sent to client components

### DIFF
--- a/__tests__/authkit-provider.spec.tsx
+++ b/__tests__/authkit-provider.spec.tsx
@@ -219,7 +219,6 @@ describe('useAuth', () => {
       permissions: ['read', 'write'],
       entitlements: ['feature1'],
       impersonator: { email: 'admin@example.com' },
-      oauthTokens: { access_token: 'token123' },
     });
 
     const TestComponent = () => {

--- a/__tests__/authkit-provider.spec.tsx
+++ b/__tests__/authkit-provider.spec.tsx
@@ -220,7 +220,6 @@ describe('useAuth', () => {
       entitlements: ['feature1'],
       impersonator: { email: 'admin@example.com' },
       oauthTokens: { access_token: 'token123' },
-      accessToken: 'access123',
     });
 
     const TestComponent = () => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -11,6 +11,7 @@ import { getWorkOS } from './workos.js';
  * @returns The sanitized auth object
  */
 function sanitize<T extends { accessToken?: string }>(value: T) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { accessToken, ...sanitized } = value;
   return sanitized;
 }

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { signOut } from './auth.js';
+import { NoUserInfo, UserInfo } from './interfaces.js';
 import { refreshSession, withAuth } from './session.js';
 import { getWorkOS } from './workos.js';
 
@@ -10,7 +11,7 @@ import { getWorkOS } from './workos.js';
  * @param value - The auth object to sanitize
  * @returns The sanitized auth object
  */
-function sanitize<T extends { accessToken?: string }>(value: T) {
+function sanitize<T extends UserInfo | NoUserInfo>(value: T) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { accessToken, ...sanitized } = value;
   return sanitized;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -5,6 +5,17 @@ import { refreshSession, withAuth } from './session.js';
 import { getWorkOS } from './workos.js';
 
 /**
+ * This function is used to sanitize the auth object.
+ * Remove the accessToken from the auth object as it is not needed on the client side.
+ * @param value - The auth object to sanitize
+ * @returns The sanitized auth object
+ */
+function sanitize<T extends { accessToken?: string }>(value: T) {
+  const { accessToken, ...sanitized } = value;
+  return sanitized;
+}
+
+/**
  * This action is only accessible to authenticated users,
  * there is no need to check the session here as the middleware will
  * be responsible for that.
@@ -22,7 +33,7 @@ export const getOrganizationAction = async (organizationId: string) => {
 };
 
 export const getAuthAction = async (options?: { ensureSignedIn?: boolean }) => {
-  return await withAuth(options);
+  return sanitize(await withAuth(options));
 };
 
 export const refreshAuthAction = async ({
@@ -32,5 +43,5 @@ export const refreshAuthAction = async ({
   ensureSignedIn?: boolean;
   organizationId?: string;
 }) => {
-  return await refreshSession({ ensureSignedIn, organizationId });
+  return sanitize(await refreshSession({ ensureSignedIn, organizationId }));
 };

--- a/src/components/authkit-provider.tsx
+++ b/src/components/authkit-provider.tsx
@@ -12,7 +12,6 @@ type AuthContextType = {
   permissions: string[] | undefined;
   entitlements: string[] | undefined;
   impersonator: Impersonator | undefined;
-  accessToken: string | undefined;
   loading: boolean;
   getAuth: (options?: { ensureSignedIn?: boolean }) => Promise<void>;
   refreshAuth: (options?: { ensureSignedIn?: boolean; organizationId?: string }) => Promise<void | { error: string }>;
@@ -38,7 +37,6 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
   const [permissions, setPermissions] = useState<string[] | undefined>(undefined);
   const [entitlements, setEntitlements] = useState<string[] | undefined>(undefined);
   const [impersonator, setImpersonator] = useState<Impersonator | undefined>(undefined);
-  const [accessToken, setAccessToken] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(true);
 
   const getAuth = async ({ ensureSignedIn = false }: { ensureSignedIn?: boolean } = {}) => {
@@ -51,7 +49,6 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
       setPermissions(auth.permissions);
       setEntitlements(auth.entitlements);
       setImpersonator(auth.impersonator);
-      setAccessToken(auth.accessToken);
     } catch (error) {
       setUser(null);
       setSessionId(undefined);
@@ -60,7 +57,6 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
       setPermissions(undefined);
       setEntitlements(undefined);
       setImpersonator(undefined);
-      setAccessToken(undefined);
     } finally {
       setLoading(false);
     }
@@ -81,7 +77,6 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
       setPermissions(auth.permissions);
       setEntitlements(auth.entitlements);
       setImpersonator(auth.impersonator);
-      setAccessToken(auth.accessToken);
     } catch (error) {
       return error instanceof Error ? { error: error.message } : { error: String(error) };
     } finally {
@@ -154,7 +149,6 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
         permissions,
         entitlements,
         impersonator,
-        accessToken,
         loading,
         getAuth,
         refreshAuth,


### PR DESCRIPTION
**Breaking change**

This removes `accessToken` from being accessible in client components. The following is no longer allowed.

```typescript
const { accessToken } = useAuth(); // no longer accessible
```

This pull request focuses on removing the `accessToken` from the client-side code to enhance security and simplify the auth object. The most important changes include sanitizing the auth object, updating actions to use the sanitized auth object, and modifying components to remove references to `accessToken`.

### Security Improvements:
* Added a `sanitize` function to remove the `accessToken` from the auth object before it is used on the client side. (`src/actions.ts`)
* Updated `getAuthAction` and `refreshAuthAction` to use the `sanitize` function. (`src/actions.ts`) [[1]](diffhunk://#diff-1b65654b4e6a4ad772c76520a607abec72eb17b56caaace589a3c5c51a21fdcbL25-R36) [[2]](diffhunk://#diff-1b65654b4e6a4ad772c76520a607abec72eb17b56caaace589a3c5c51a21fdcbL35-R46)

### Component Updates:
* Removed `accessToken` from the `AuthContextType` type definition. (`src/components/authkit-provider.tsx`)
* Removed `accessToken` state and related code from the `AuthKitProvider` component. (`src/components/authkit-provider.tsx`) [[1]](diffhunk://#diff-5ff17fea1fc95fa55adfd7e345657a5df19aa7ebfd3ba619f66fda027b523041L41) [[2]](diffhunk://#diff-5ff17fea1fc95fa55adfd7e345657a5df19aa7ebfd3ba619f66fda027b523041L54) [[3]](diffhunk://#diff-5ff17fea1fc95fa55adfd7e345657a5df19aa7ebfd3ba619f66fda027b523041L63) [[4]](diffhunk://#diff-5ff17fea1fc95fa55adfd7e345657a5df19aa7ebfd3ba619f66fda027b523041L84) [[5]](diffhunk://#diff-5ff17fea1fc95fa55adfd7e345657a5df19aa7ebfd3ba619f66fda027b523041L157)

### Test Adjustments:
* Removed `accessToken` from test mock data in `useAuth` test suite. (`__tests__/authkit-provider.spec.tsx`)