### PR TITLE
fix: getAuthorizationUrl calls don't always include custom redirectUri set in middleware

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -126,6 +126,12 @@ async function updateSession(
   // `pathname` to be able to return the users where they came from before sign-in
   newRequestHeaders.set('x-url', request.url);
 
+  if (options.redirectUri) {
+    // Store the redirect URI in a custom header, so we always have access to it and so that subsequent
+    // calls to `getAuthorizationUrl` will use the same redirect URI
+    newRequestHeaders.set('x-redirect-uri', options.redirectUri);
+  }
+
   newRequestHeaders.delete(sessionHeaderName);
 
   if (!session) {


### PR DESCRIPTION
This pull request includes a change to the `src/session.ts` file to improve the handling of redirect URIs during session updates.

## Example 

In your middleware configuration, provide a `redirectUri` override.

```ts
export default authkitMiddleware({
  redirectUri: 'http://localhost:3000/foo'
});
```

Then, while being not logged in, click on a page that contains `withAuth({ ensureSignedIn: true });`

This will now cause a redirect to the `redirectUri` value provided to the middleware, as it was added to the headers as `x-redirect-uri`, which is alreayd being checked by the `getAuthorizationUrl` call.

## Improvements to session handling:

* [`src/session.ts`](diffhunk://#diff-96998a2148aa3d52ad3e80303d0ad88fc43a4afd08966b5330a5657021ae52bbR129-R134): Added a check for `options.redirectUri` and, if present, stored it in a custom header `x-redirect-uri` to ensure subsequent calls to `getAuthorizationUrl` use the same redirect URI.