### PR TITLE
adding support for login_hint to getSignInUrl

### DIFF
--- a/src/get-authorization-url.ts
+++ b/src/get-authorization-url.ts
@@ -5,7 +5,7 @@ import { headers } from 'next/headers';
 
 async function getAuthorizationUrl(options: GetAuthURLOptions = {}) {
   const headersList = await headers();
-  const { returnPathname, screenHint, organizationId, redirectUri = headersList.get('x-redirect-uri') } = options;
+  const { returnPathname, screenHint, organizationId, redirectUri = headersList.get('x-redirect-uri'), loginHint } = options;
 
   return getWorkOS().userManagement.getAuthorizationUrl({
     provider: 'authkit',
@@ -14,6 +14,7 @@ async function getAuthorizationUrl(options: GetAuthURLOptions = {}) {
     state: returnPathname ? btoa(JSON.stringify({ returnPathname })) : undefined,
     screenHint,
     organizationId,
+    loginHint,
   });
 }
 

--- a/src/get-authorization-url.ts
+++ b/src/get-authorization-url.ts
@@ -5,7 +5,13 @@ import { headers } from 'next/headers';
 
 async function getAuthorizationUrl(options: GetAuthURLOptions = {}) {
   const headersList = await headers();
-  const { returnPathname, screenHint, organizationId, redirectUri = headersList.get('x-redirect-uri'), loginHint } = options;
+  const {
+    returnPathname,
+    screenHint,
+    organizationId,
+    redirectUri = headersList.get('x-redirect-uri'),
+    loginHint,
+  } = options;
 
   return getWorkOS().userManagement.getAuthorizationUrl({
     provider: 'authkit',

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,6 +57,7 @@ export interface GetAuthURLOptions {
   returnPathname?: string;
   organizationId?: string;
   redirectUri?: string;
+  loginHint?: string;
 }
 
 export interface AuthkitMiddlewareAuth {


### PR DESCRIPTION
`login_hint` is supported for `getAuthorizationURL`, adding support for authkit-nextjs as an optional param that can be passesd to `getSignInUrl()`