### PR TITLE
add switchToOrganization action and client helper

### DIFF
--- a/__tests__/actions.spec.ts
+++ b/__tests__/actions.spec.ts
@@ -4,13 +4,15 @@ import {
   getOrganizationAction,
   getAuthAction,
   refreshAuthAction,
+  switchToOrganizationAction,
 } from '../src/actions.js';
-import { signOut } from '../src/auth.js';
+import { signOut, switchToOrganization } from '../src/auth.js';
 import { getWorkOS } from '../src/workos.js';
 import { withAuth, refreshSession } from '../src/session.js';
 
 jest.mock('../src/auth.js', () => ({
   signOut: jest.fn().mockResolvedValue(true),
+  switchToOrganization: jest.fn().mockResolvedValue({ organizationId: 'org_123' }),
 }));
 
 const fakeWorkosInstance = {
@@ -66,6 +68,15 @@ describe('actions', () => {
       const result = await refreshAuthAction(params);
       expect(refreshSession).toHaveBeenCalledWith(params);
       expect(result).toEqual({ session: 'newSession' });
+    });
+  });
+
+  describe('switchToOrganizationAction', () => {
+    it('should switch organizations', async () => {
+      const options = { returnTo: '/test' };
+      const result = await switchToOrganizationAction('org_123', options);
+      expect(switchToOrganization).toHaveBeenCalledWith('org_123', options);
+      expect(result).toEqual({ organizationId: 'org_123' });
     });
   });
 });

--- a/__tests__/auth.spec.ts
+++ b/__tests__/auth.spec.ts
@@ -110,10 +110,13 @@ describe('auth.ts', () => {
     });
 
     describe('on error', () => {
-      it.only('should redirect to sign in', async () => {
+      beforeEach(async () => {
         const nextHeaders = await headers();
         nextHeaders.set('x-url', 'http://localhost/test');
         await generateSession();
+      });
+
+      it('should redirect to sign in', async () => {
         authenticateWithRefreshToken.mockImplementation(() => {
           return Promise.reject({
             status: 500,
@@ -128,11 +131,17 @@ describe('auth.ts', () => {
         expect(redirect).toHaveBeenCalledTimes(1);
       });
 
-      //it('should redirect to the authkit_redirect_url when provided', async () => {
-      //  refreshSession.mockRejectedValue({ rawData: { authkit_redirect_url: 'http://localhost/test' } });
-      //  await switchToOrganization('org_123');
-      //  expect(redirect).toHaveBeenCalledWith('http://localhost/test');
-      //});
+      it('should redirect to the authkit_redirect_url when provided', async () => {
+        authenticateWithRefreshToken.mockImplementation(() => {
+          return Promise.reject({
+            rawData: {
+              authkit_redirect_url: 'http://localhost/test',
+            },
+          });
+        });
+        await switchToOrganization('org_123');
+        expect(redirect).toHaveBeenCalledWith('http://localhost/test');
+      });
     });
   });
 

--- a/__tests__/test-helpers.ts
+++ b/__tests__/test-helpers.ts
@@ -1,4 +1,8 @@
+import { sealData } from 'iron-session';
 import { SignJWT } from 'jose';
+import { WORKOS_COOKIE_NAME, WORKOS_COOKIE_PASSWORD } from '../src/env-variables.js';
+import { cookies } from 'next/headers';
+import { User } from '@workos-inc/node';
 
 export async function generateTestToken(payload = {}, expired = false) {
   const defaultPayload = {
@@ -21,4 +25,40 @@ export async function generateTestToken(payload = {}, expired = false) {
     .sign(secret);
 
   return token;
+}
+
+export async function generateSession(overrides: Partial<User> = {}) {
+  const mockUser = {
+    id: 'user_123',
+    email: 'test@example.com',
+    emailVerified: true,
+    profilePictureUrl: null,
+    firstName: 'Test',
+    lastName: 'User',
+    object: 'user',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  } satisfies User;
+
+  const accessToken = await generateTestToken({
+    sid: 'session_123',
+    org_id: 'org_123',
+  });
+
+  // Create and set a session cookie
+  const encryptedSession = await sealData(
+    {
+      accessToken,
+      refreshToken: 'refresh_token_123',
+      user: mockUser,
+    },
+    {
+      password: WORKOS_COOKIE_PASSWORD as string,
+    },
+  );
+
+  const cookieName = WORKOS_COOKIE_NAME || 'wos-session';
+  const nextCookies = await cookies();
+  nextCookies.set(cookieName, encryptedSession);
 }

--- a/__tests__/test-helpers.ts
+++ b/__tests__/test-helpers.ts
@@ -1,3 +1,5 @@
+// istanbul ignore file
+
 import { sealData } from 'iron-session';
 import { SignJWT } from 'jose';
 import { WORKOS_COOKIE_NAME, WORKOS_COOKIE_PASSWORD } from '../src/env-variables.js';

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
-import { signOut } from './auth.js';
-import { NoUserInfo, UserInfo } from './interfaces.js';
+import { signOut, switchToOrganization } from './auth.js';
+import { NoUserInfo, UserInfo, SwitchToOrganizationOptions } from './interfaces.js';
 import { refreshSession, withAuth } from './session.js';
 import { getWorkOS } from './workos.js';
 
@@ -46,4 +46,8 @@ export const refreshAuthAction = async ({
   organizationId?: string;
 }) => {
   return sanitize(await refreshSession({ ensureSignedIn, organizationId }));
+};
+
+export const switchToOrganizationAction = async (organizationId: string, options?: SwitchToOrganizationOptions) => {
+  return sanitize(await switchToOrganization(organizationId, options));
 };

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -43,7 +43,7 @@ export async function switchToOrganization(
   const { returnTo, revalidationStrategy = 'path', revalidationTags = [] } = options;
   const headersList = await headers();
   const pathname = returnTo || headersList.get('x-url') || '/';
-  const result = refreshSession({ organizationId, ensureSignedIn: true });
+  const result = await refreshSession({ organizationId, ensureSignedIn: true });
 
   switch (revalidationStrategy) {
     case 'path':

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -42,6 +42,7 @@ export async function switchToOrganization(
 ): Promise<UserInfo> {
   const { returnTo, revalidationStrategy = 'path', revalidationTags = [] } = options;
   const headersList = await headers();
+  // istanbul ignore next
   const pathname = returnTo || headersList.get('x-url') || '/';
   const result = await refreshSession({ organizationId, ensureSignedIn: true });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -52,6 +52,7 @@ export async function switchToOrganization(
     error: any
   ) {
     const { cause } = error;
+    /* istanbul ignore next */
     if (cause?.rawData?.authkit_redirect_url) {
       redirect(cause.rawData.authkit_redirect_url);
     } else {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -57,7 +57,7 @@ export async function switchToOrganization(
     } else {
       if (cause?.error === 'sso_required' || cause?.error === 'mfa_enrollment') {
         const url = await getAuthorizationUrl({ organizationId });
-        redirect(url);
+        return redirect(url);
       }
       throw error;
     }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,11 +1,14 @@
 'use server';
 
 import { getAuthorizationUrl } from './get-authorization-url.js';
-import { cookies } from 'next/headers';
-import { terminateSession } from './session.js';
+import { cookies, headers } from 'next/headers';
+import { refreshSession, terminateSession } from './session.js';
 import { WORKOS_COOKIE_NAME, WORKOS_COOKIE_DOMAIN } from './env-variables.js';
+import { revalidatePath, revalidateTag } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { UserInfo, SwitchToOrganizationOptions } from './interfaces.js';
 
-async function getSignInUrl({
+export async function getSignInUrl({
   organizationId,
   loginHint,
   redirectUri,
@@ -13,7 +16,7 @@ async function getSignInUrl({
   return getAuthorizationUrl({ organizationId, screenHint: 'sign-in', loginHint, redirectUri });
 }
 
-async function getSignUpUrl({
+export async function getSignUpUrl({
   organizationId,
   loginHint,
   redirectUri,
@@ -21,7 +24,7 @@ async function getSignUpUrl({
   return getAuthorizationUrl({ organizationId, screenHint: 'sign-up', loginHint, redirectUri });
 }
 
-async function signOut({ returnTo }: { returnTo?: string } = {}) {
+export async function signOut({ returnTo }: { returnTo?: string } = {}) {
   const cookie: { name: string; domain?: string } = {
     name: WORKOS_COOKIE_NAME || 'wos-session',
   };
@@ -33,4 +36,28 @@ async function signOut({ returnTo }: { returnTo?: string } = {}) {
   await terminateSession({ returnTo });
 }
 
-export { getSignInUrl, getSignUpUrl, signOut };
+export async function switchToOrganization(
+  organizationId: string,
+  options: SwitchToOrganizationOptions = {},
+): Promise<UserInfo> {
+  const { returnTo, revalidationStrategy = 'path', revalidationTags = [] } = options;
+  const headersList = await headers();
+  const pathname = returnTo || headersList.get('x-url') || '/';
+  const result = refreshSession({ organizationId, ensureSignedIn: true });
+
+  switch (revalidationStrategy) {
+    case 'path':
+      revalidatePath(pathname);
+      break;
+    case 'tag':
+      for (const tag of revalidationTags) {
+        revalidateTag(tag);
+      }
+      break;
+  }
+  if (revalidationStrategy !== 'none') {
+    redirect(pathname);
+  }
+
+  return result;
+}

--- a/src/components/authkit-provider.tsx
+++ b/src/components/authkit-provider.tsx
@@ -1,8 +1,15 @@
 'use client';
 
 import React, { createContext, ReactNode, useContext, useEffect, useState } from 'react';
-import { checkSessionAction, getAuthAction, handleSignOutAction, refreshAuthAction } from '../actions.js';
+import {
+  checkSessionAction,
+  getAuthAction,
+  handleSignOutAction,
+  refreshAuthAction,
+  switchToOrganizationAction,
+} from '../actions.js';
 import type { Impersonator, User } from '@workos-inc/node';
+import type { UserInfo, SwitchToOrganizationOptions } from '../interfaces.js';
 
 type AuthContextType = {
   user: User | null;
@@ -16,6 +23,10 @@ type AuthContextType = {
   getAuth: (options?: { ensureSignedIn?: boolean }) => Promise<void>;
   refreshAuth: (options?: { ensureSignedIn?: boolean; organizationId?: string }) => Promise<void | { error: string }>;
   signOut: (options?: { returnTo?: string }) => Promise<void>;
+  switchToOrganization: (
+    organizationId: string,
+    options?: SwitchToOrganizationOptions,
+  ) => Promise<Omit<UserInfo, 'accessToken'> | { error: string }>;
 };
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -59,6 +70,14 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
       setImpersonator(undefined);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const switchToOrganization = async (organizationId: string, options: SwitchToOrganizationOptions = {}) => {
+    try {
+      return await switchToOrganizationAction(organizationId, options);
+    } catch (error) {
+      return error instanceof Error ? { error: error.message } : { error: String(error) };
     }
   };
 
@@ -153,6 +172,7 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
         getAuth,
         refreshAuth,
         signOut,
+        switchToOrganization,
       }}
     >
       {children}

--- a/src/components/authkit-provider.tsx
+++ b/src/components/authkit-provider.tsx
@@ -51,6 +51,7 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
   const [loading, setLoading] = useState(true);
 
   const getAuth = async ({ ensureSignedIn = false }: { ensureSignedIn?: boolean } = {}) => {
+    setLoading(true);
     try {
       const auth = await getAuthAction({ ensureSignedIn });
       setUser(auth.user);
@@ -74,11 +75,17 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
   };
 
   const switchToOrganization = async (organizationId: string, options: SwitchToOrganizationOptions = {}) => {
-    try {
-      return await switchToOrganizationAction(organizationId, options);
-    } catch (error) {
-      return error instanceof Error ? { error: error.message } : { error: String(error) };
+    const opts = { revalidationStrategy: 'none', ...options };
+    const result = await switchToOrganizationAction(organizationId, {
+      revalidationStrategy: 'none',
+      ...options,
+    });
+
+    if (opts.revalidationStrategy === 'none') {
+      await getAuth({ ensureSignedIn: true });
     }
+
+    return result;
   };
 
   const refreshAuth = async ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { handleAuth } from './authkit-callback-route.js';
 import { authkit, authkitMiddleware } from './middleware.js';
 import { withAuth, refreshSession } from './session.js';
-import { getSignInUrl, getSignUpUrl, signOut } from './auth.js';
+import { getSignInUrl, getSignUpUrl, signOut, switchToOrganization } from './auth.js';
 import { getWorkOS } from './workos.js';
 
 export * from './interfaces.js';
@@ -18,4 +18,5 @@ export {
   withAuth,
   refreshSession,
   signOut,
+  switchToOrganization,
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -92,3 +92,9 @@ export interface CookieOptions {
   maxAge: number;
   domain: string | undefined;
 }
+
+export interface SwitchToOrganizationOptions {
+  returnTo?: string;
+  revalidationStrategy?: 'none' | 'tag' | 'path';
+  revalidationTags?: string[];
+}


### PR DESCRIPTION
# Add Organization Switching Support

This PR adds a `switchToOrganization` function to AuthKit for NextJS, enabling users to switch between organizations with proper page revalidation.

## Features

- Server-side organization switching with flexible revalidation strategies
- Client-side support via the `useAuth` hook
- Support for path and tag-based revalidation

## Examples

### Server Component 

```tsx
// In a server component or server action
import { switchToOrganization } from '@workos-inc/authkit-nextjs';

// Switch with default behavior (path revalidation)
await switchToOrganization('org_123');

// With custom options
await switchToOrganization('org_123', {
  returnTo: '/dashboard',
  revalidationStrategy: 'tag',
  revalidationTags: ['org-data']
});
```

### Client Component

```tsx
// In a client component
import { useAuth } from '@workos-inc/authkit-nextjs/components';

function OrganizationSwitcher() {
  const { organizationId, switchToOrganization } = useAuth();
  
  return (
    <select 
      value={organizationId} 
      onChange={(e) => switchToOrganization(e.target.value)}
    >
      {/* Organization options */}
    </select>
  );
}
```

This feature complements the Organization Switcher widget and provides a standardized approach for handling organization switching in NextJS applications.