### PR TITLE
improve type narrowing on refreshSession

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -251,19 +251,18 @@ async function updateSession(
   }
 }
 
-async function refreshSession(options: {
+async function refreshSession(options: { organizationId?: string; ensureSignedIn: true }): Promise<UserInfo>;
+async function refreshSession(options?: {
   organizationId?: string;
   ensureSignedIn?: boolean;
 }): Promise<UserInfo | NoUserInfo>;
-
-/* istanbul ignore next */
 async function refreshSession({
   organizationId: nextOrganizationId,
   ensureSignedIn = false,
 }: {
   organizationId?: string;
   ensureSignedIn?: boolean;
-} = {}) {
+} = {}): Promise<UserInfo | NoUserInfo> {
   const session = await getSessionFromCookie();
   if (!session) {
     if (ensureSignedIn) {


### PR DESCRIPTION
When passing `ensureSignedIn: true` to `refreshSession`, the type can be narrowed to ensure that the function always returns `Promise<UserInfo>`.

```typescript
const a = await refreshSession(); // UserInfo | NoUserInfo

const b = await refreshSession({ ensureSignedIn: true }); // UserInfo
```