### PR TITLE
add WORKOS_COOKIE_SAMESITE optional configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ WORKOS_COOKIE_NAME='authkit-cookie'
 WORKOS_API_HOSTNAME='api.workos.com' # base WorkOS API URL
 WORKOS_API_HTTPS=true # whether to use HTTPS in API calls
 WORKOS_API_PORT=3000 # port to use for API calls
+
+# Only change this if you specifically need cross-origin cookie support.
+WORKOS_COOKIE_SAMESITE='lax' # SameSite attribute for cookies: 'lax' (default), 'strict', or 'none'.
+
+>[!IMPORTANT] Security Note:
+>Setting WORKOS_COOKIE_SAMESITE='none' allows cookies to be sent in cross-origin contexts (like iframes), but reduces protection against CSRF attacks. This setting forces cookies to be secure (HTTPS only) and should only be used when absolutely necessary for your application architecture.
 ```
 
 `WORKOS_COOKIE_DOMAIN` can be used to share WorkOS sessions between apps/domains.

--- a/README.md
+++ b/README.md
@@ -57,14 +57,13 @@ WORKOS_API_PORT=3000 # port to use for API calls
 
 # Only change this if you specifically need cross-origin cookie support.
 WORKOS_COOKIE_SAMESITE='lax' # SameSite attribute for cookies: 'lax' (default), 'strict', or 'none'.
-
->[!IMPORTANT] Security Note:
->Setting WORKOS_COOKIE_SAMESITE='none' allows cookies to be sent in cross-origin contexts (like iframes), but reduces protection against CSRF attacks. This setting forces cookies to be secure (HTTPS only) and should only be used when absolutely necessary for your application architecture.
 ```
 
-`WORKOS_COOKIE_DOMAIN` can be used to share WorkOS sessions between apps/domains.
-Note: The `WORKOS_COOKIE_PASSWORD` would need to be the same across apps/domains.
-Not needed for most use cases.
+>[!WARNING]
+>Setting `WORKOS_COOKIE_SAMESITE='none'` allows cookies to be sent in cross-origin contexts (like iframes), but reduces protection against CSRF attacks. This setting forces cookies to be secure (HTTPS only) and should only be used when absolutely necessary for your application architecture.
+
+>[!TIP]
+>`WORKOS_COOKIE_DOMAIN` can be used to share WorkOS sessions between apps/domains. Note: The `WORKOS_COOKIE_PASSWORD` would need to be the same across apps/domains. Not needed for most use cases.
 
 ## Setup
 

--- a/__tests__/cookie.spec.ts
+++ b/__tests__/cookie.spec.ts
@@ -73,13 +73,30 @@ describe('cookie.ts', () => {
       const { getCookieOptions } = await import('../src/cookie');
       const options = getCookieOptions('http://example.com', true, false);
       expect(options).toEqual(
-        expect.stringContaining('Path=/; HttpOnly; Secure=false; SameSite="Lax"; Max-Age=34560000; Domain=example.com'),
+        expect.stringContaining('Path=/; HttpOnly; Secure=false; SameSite="lax"; Max-Age=34560000; Domain=example.com'),
       );
 
       const options2 = getCookieOptions('https://example.com', true, true);
       expect(options2).toEqual(
-        expect.stringContaining('Path=/; HttpOnly; Secure=true; SameSite="Lax"; Max-Age=0; Domain=example.com'),
+        expect.stringContaining('Path=/; HttpOnly; Secure=true; SameSite="lax"; Max-Age=0; Domain=example.com'),
       );
+    });
+
+    it('allows the sameSite config to be set by the WORKOS_COOKIE_SAMESITE env variable', async () => {
+      const envVars = await import('../src/env-variables');
+      Object.defineProperty(envVars, 'WORKOS_COOKIE_SAMESITE', { value: 'none' });
+
+      const { getCookieOptions } = await import('../src/cookie');
+      const options = getCookieOptions('http://example.com');
+      expect(options).toEqual(expect.objectContaining({ sameSite: 'none' }));
+    });
+
+    it('throws an error if the sameSite value is invalid', async () => {
+      const envVars = await import('../src/env-variables');
+      Object.defineProperty(envVars, 'WORKOS_COOKIE_SAMESITE', { value: 'invalid' });
+
+      const { getCookieOptions } = await import('../src/cookie');
+      expect(() => getCookieOptions('http://example.com')).toThrow('Invalid SameSite value: invalid');
     });
   });
 });

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -33,7 +33,7 @@ export function getCookieOptions(
   expired: boolean = false,
 ): CookieOptions | string {
   const url = new URL(redirectUri || WORKOS_REDIRECT_URI);
-  const sameSite = WORKOS_COOKIE_SAMESITE || 'Lax';
+  const sameSite = WORKOS_COOKIE_SAMESITE || 'lax';
   assertValidSamSite(sameSite);
   const secure = sameSite.toLowerCase() === 'none' ? true : url.protocol === 'https:';
 

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -1,5 +1,18 @@
-import { WORKOS_REDIRECT_URI, WORKOS_COOKIE_MAX_AGE, WORKOS_COOKIE_DOMAIN } from './env-variables.js';
+import {
+  WORKOS_REDIRECT_URI,
+  WORKOS_COOKIE_MAX_AGE,
+  WORKOS_COOKIE_DOMAIN,
+  WORKOS_COOKIE_SAMESITE,
+} from './env-variables.js';
 import { CookieOptions } from './interfaces.js';
+
+type ValidSameSite = CookieOptions['sameSite'];
+
+function assertValidSamSite(sameSite: string): asserts sameSite is ValidSameSite {
+  if (!['lax', 'strict', 'none'].includes(sameSite.toLowerCase())) {
+    throw new Error(`Invalid SameSite value: ${sameSite}`);
+  }
+}
 
 export function getCookieOptions(): CookieOptions;
 export function getCookieOptions(redirectUri?: string | null): CookieOptions;
@@ -20,16 +33,19 @@ export function getCookieOptions(
   expired: boolean = false,
 ): CookieOptions | string {
   const url = new URL(redirectUri || WORKOS_REDIRECT_URI);
+  const sameSite = WORKOS_COOKIE_SAMESITE || 'Lax';
+  assertValidSamSite(sameSite);
+  const secure = sameSite.toLowerCase() === 'none' ? true : url.protocol === 'https:';
 
   const maxAge = expired ? 0 : WORKOS_COOKIE_MAX_AGE ? parseInt(WORKOS_COOKIE_MAX_AGE, 10) : 60 * 60 * 24 * 400;
 
   return asString
-    ? `Path=/; HttpOnly; Secure=${url.protocol === 'https:'}; SameSite="Lax"; Max-Age=${maxAge}; Domain=${WORKOS_COOKIE_DOMAIN || ''}`
+    ? `Path=/; HttpOnly; Secure=${secure}; SameSite="${sameSite}"; Max-Age=${maxAge}; Domain=${WORKOS_COOKIE_DOMAIN || ''}`
     : {
         path: '/',
         httpOnly: true,
-        secure: url.protocol === 'https:',
-        sameSite: 'lax' as const,
+        secure,
+        sameSite,
         // Defaults to 400 days, the maximum allowed by Chrome
         // It's fine to have a long cookie expiry date as the access/refresh tokens
         // act as the actual time-limited aspects of the session.

--- a/src/env-variables.ts
+++ b/src/env-variables.ts
@@ -11,6 +11,7 @@ const WORKOS_API_PORT = getEnvVariable('WORKOS_API_PORT');
 const WORKOS_COOKIE_DOMAIN = getEnvVariable('WORKOS_COOKIE_DOMAIN');
 const WORKOS_COOKIE_MAX_AGE = getEnvVariable('WORKOS_COOKIE_MAX_AGE');
 const WORKOS_COOKIE_NAME = getEnvVariable('WORKOS_COOKIE_NAME');
+const WORKOS_COOKIE_SAMESITE = getEnvVariable('WORKOS_COOKIE_SAMESITE');
 
 // Required env variables
 const WORKOS_API_KEY = getEnvVariable('WORKOS_API_KEY') ?? '';
@@ -29,4 +30,5 @@ export {
   WORKOS_COOKIE_NAME,
   WORKOS_COOKIE_PASSWORD,
   WORKOS_REDIRECT_URI,
+  WORKOS_COOKIE_SAMESITE,
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -88,7 +88,7 @@ export interface CookieOptions {
   path: '/';
   httpOnly: true;
   secure: boolean;
-  sameSite: 'lax';
+  sameSite: 'lax' | 'strict' | 'none';
   maxAge: number;
   domain: string | undefined;
 }


### PR DESCRIPTION
Add option to configure the [samesite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies#controlling_third-party_cookies_with_samesite) cookie setting for specific use cases.

![capture_20250317_115039](https://github.com/user-attachments/assets/233dcb0d-a98c-44a7-80df-e602d3c500ec)

Fixes #216 