### PR TITLE
Expose a saveSession method for advanced use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,8 +455,7 @@ async function handleEmailVerification(req) {
 ```
 
 >[!NOTE]
->This is an advanced API intended for specific integration scenarios. Most applications should use the standard
->authentication flow.
+>This is an advanced API intended for specific integration scenarios, such as those users using self-hosted AuthKit. If you're using hosted AuthKit you should not need this.
 
 The `saveSession` function accepts either a `NextRequest` object or a URL string as its second parameter.
 

--- a/README.md
+++ b/README.md
@@ -422,6 +422,52 @@ const organizations = await workos.organizations.listOrganizations({
 });
 ````
 
+### Advanced: Custom authentication flows
+
+While the standard authentication flow handles session management automatically, some use cases require manually creating and storing a session. This is useful for custom authentication flows like email verification or token exchange.
+
+For these scenarios, you can use the `saveSession` function:
+
+```typescript
+import { saveSession } from '@workos-inc/authkit-nextjs';
+import { getWorkOS } from '@workos-inc/authkit-nextjs';
+
+// Example: Email verification flow
+async function handleEmailVerification(req) {
+  const { code } = await req.json();
+
+  // Authenticate with the WorkOS API directly
+  const authResponse = await getWorkOS().userManagement.authenticateWithEmailVerification({
+    clientId: process.env.WORKOS_CLIENT_ID,
+    code,
+  });
+
+  // Save the session data to a cookie
+  await saveSession({
+    accessToken: authResponse.accessToken,
+    refreshToken: authResponse.refreshToken,
+    user: authResponse.user,
+    impersonator: authResponse.impersonator
+  }, req);
+
+  return Response.redirect('/dashboard');
+}
+```
+
+>[!NOTE]
+>This is an advanced API intended for specific integration scenarios. Most applications should use the standard
+>authentication flow.
+
+The `saveSession` function accepts either a `NextRequest` object or a URL string as its second parameter.
+
+```typescript
+// With NextRequest
+await saveSession(session, req);
+
+// With URL string
+await saveSession(session, 'https://example.com/callback');
+```
+
 ### Debugging
 
 To enable debug logs, initialize the middleware with the debug flag enabled.

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -1,9 +1,7 @@
-import { cookies } from 'next/headers';
 import { NextRequest } from 'next/server';
-import { getCookieOptions } from './cookie.js';
-import { WORKOS_CLIENT_ID, WORKOS_COOKIE_NAME } from './env-variables.js';
+import { WORKOS_CLIENT_ID } from './env-variables.js';
 import { HandleAuthOptions } from './interfaces.js';
-import { encryptSession } from './session.js';
+import { saveSession } from './session.js';
 import { errorResponseWithFallback, redirectWithFallback } from './utils.js';
 import { getWorkOS } from './workos.js';
 
@@ -67,13 +65,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
           await onSuccess({ accessToken, refreshToken, user, impersonator, oauthTokens });
         }
 
-        // The refreshToken should never be accesible publicly, hence why we encrypt it in the cookie session
-        // Alternatively you could persist the refresh token in a backend database
-        const session = await encryptSession({ accessToken, refreshToken, user, impersonator });
-        const cookieName = WORKOS_COOKIE_NAME || 'wos-session';
-        const nextCookies = await cookies();
-
-        nextCookies.set(cookieName, session, getCookieOptions(request.url));
+        await saveSession({ accessToken, refreshToken, user, impersonator }, request);
 
         return response;
       } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,21 @@
+import { getSignInUrl, getSignUpUrl, signOut, switchToOrganization } from './auth.js';
 import { handleAuth } from './authkit-callback-route.js';
 import { authkit, authkitMiddleware } from './middleware.js';
-import { withAuth, refreshSession } from './session.js';
-import { getSignInUrl, getSignUpUrl, signOut, switchToOrganization } from './auth.js';
+import { refreshSession, saveSession, withAuth } from './session.js';
 import { getWorkOS } from './workos.js';
 
 export * from './interfaces.js';
 
 export {
-  getWorkOS,
-  handleAuth,
-  //
-  authkitMiddleware,
   authkit,
-  //
+  authkitMiddleware,
   getSignInUrl,
   getSignUpUrl,
-  withAuth,
+  getWorkOS,
+  handleAuth,
   refreshSession,
+  saveSession,
   signOut,
   switchToOrganization,
+  withAuth,
 };

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,7 +14,6 @@ import {
   AuthkitMiddlewareAuth,
   AuthkitOptions,
   AuthkitResponse,
-  CookieOptions,
   NoUserInfo,
   Session,
   UserInfo,
@@ -287,22 +286,12 @@ async function refreshSession({
     });
   }
 
-  const { accessToken, refreshToken, user, impersonator } = refreshResult;
-  // Encrypt session with new access and refresh tokens
-  const encryptedSession = await encryptSession({
-    accessToken,
-    refreshToken,
-    user,
-    impersonator,
-  });
-
-  const cookieName = WORKOS_COOKIE_NAME || 'wos-session';
-
   const headersList = await headers();
   const url = headersList.get('x-url');
 
-  const nextCookies = await cookies();
-  nextCookies.set(cookieName, encryptedSession, getCookieOptions(url) as CookieOptions);
+  await saveSession(refreshResult, url || WORKOS_REDIRECT_URI);
+
+  const { accessToken, user, impersonator } = refreshResult;
 
   const {
     sid: sessionId,
@@ -460,6 +449,47 @@ function getScreenHint(signUpPaths: string[] | undefined, pathname: string) {
   });
 
   return screenHintPaths.length > 0 ? 'sign-up' : 'sign-in';
+}
+
+/**
+ * Saves a WorkOS session to a cookie for use with AuthKit.
+ *
+ * This function is intended for advanced use cases where you need to manually manage sessions,
+ * such as custom authentication flows (email verification, etc.) that don't use
+ * the standard AuthKit authentication flow.
+ *
+ * @param session The WorkOS session containing access token, refresh token, and user information.
+ * @param request Either a NextRequest object or a URL string, used to determine cookie settings.
+ *
+ * @example
+ * // With a NextRequest object
+ * import { saveSession } from '@workos-inc/authkit-nextjs';
+ *
+ * async function handleEmailVerification(req: NextRequest) {
+ *   const { code } = await req.json();
+ *   const authResponse = await workos.userManagement.authenticateWithEmailVerification({
+ *     clientId: process.env.WORKOS_CLIENT_ID,
+ *     code,
+ *   });
+ *
+ *   await saveSession({
+ *     accessToken: authResponse.accessToken,
+ *     refreshToken: authResponse.refreshToken,
+ *     user: authResponse.user,
+ *     impersonator: authResponse.impersonator
+ *   }, req);
+ * }
+ *
+ * @example
+ * // With a URL string
+ * await saveSession(session, 'https://example.com/callback');
+ */
+export async function saveSession(session: Session, request: NextRequest | string): Promise<void> {
+  const cookieName = WORKOS_COOKIE_NAME || 'wos-session';
+  const encryptedSession = await encryptSession(session);
+  const nextCookies = await cookies();
+  const url = typeof request === 'string' ? request : request.url;
+  nextCookies.set(cookieName, encryptedSession, getCookieOptions(url));
 }
 
 export { encryptSession, withAuth, refreshSession, terminateSession, updateSessionMiddleware, updateSession };

--- a/src/session.ts
+++ b/src/session.ts
@@ -473,17 +473,12 @@ function getScreenHint(signUpPaths: string[] | undefined, pathname: string) {
  *     code,
  *   });
  *
- *   await saveSession({
- *     accessToken: authResponse.accessToken,
- *     refreshToken: authResponse.refreshToken,
- *     user: authResponse.user,
- *     impersonator: authResponse.impersonator
- *   }, req);
+ *   await saveSession(authResponse, req);
  * }
  *
  * @example
  * // With a URL string
- * await saveSession(session, 'https://example.com/callback');
+ * await saveSession(authResponse, 'https://example.com/callback');
  */
 export async function saveSession(
   sessionOrResponse: Session | AuthenticationResponse,


### PR DESCRIPTION
This PR adds and exposes a new `saveSession` method for advanced end-user cases. It also replaces duplicated code internally with calls to this.

---

While the standard authentication flow handles session management automatically, some use cases require manually creating and storing a session. This is useful for custom authentication flows like email verification or token exchange.

For these scenarios, you can use the `saveSession` function:

```typescript
import { saveSession } from '@workos-inc/authkit-nextjs';
import { getWorkOS } from '@workos-inc/authkit-nextjs';

// Example: Email verification flow
async function handleEmailVerification(req) {
  const { code } = await req.json();

  // Authenticate with the WorkOS API directly
  const authResponse = await getWorkOS().userManagement.authenticateWithEmailVerification({
    clientId: process.env.WORKOS_CLIENT_ID,
    code,
  });

  // Save the session data to a cookie
  await saveSession({
    accessToken: authResponse.accessToken,
    refreshToken: authResponse.refreshToken,
    user: authResponse.user,
    impersonator: authResponse.impersonator
  }, req);

  return Response.redirect('/dashboard');
}
```

>[!NOTE]
>This is an advanced API intended for specific integration scenarios. Most applications should use the standard
>authentication flow.

The `saveSession` function accepts either a `NextRequest` object or a URL string as its second parameter.

```typescript
// With NextRequest
await saveSession(session, req);

// With URL string
await saveSession(session, 'https://example.com/callback');
```
