### PR TITLE
v2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-nextjs",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^7.37.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -2,7 +2,7 @@ import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 import { lazy } from './utils.js';
 
-export const VERSION = '2.1.0';
+export const VERSION = '2.2.0';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
- Updating peer dependency on Next.js

This pull request includes version updates for the `@workos-inc/authkit-nextjs` package. The version has been incremented from `2.1.0` to `2.2.0` in both the `package.json` file and the `VERSION` export in the `src/workos.ts` file.

Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version to `2.2.0`.
* [`src/workos.ts`](diffhunk://#diff-43fae42284da1898f98b43b56a7bc6f5fb979e271bca59f4670751ba2c0020efL5-R5): Updated the `VERSION` export to `2.2.0`.