### PR TITLE
fix: set middleware headers on request too to fix issues with netlify deploys

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -103,6 +103,7 @@ async function updateSessionMiddleware(
   }
 
   return NextResponse.next({
+    request: { headers },
     headers,
   });
 }


### PR DESCRIPTION
This change adds the middleware headers to the request as well as the response to fix an issue in Netlify deploys. Per [their docs](https://opennext.js.org/netlify#limitations) there are limitations around headers and the evaluation order.

Fixes #229 