### PR TITLE
Add client-side access to access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,66 @@ export function SwitchOrganizationButton() {
 }
 ```
 
+### Access Token Management
+
+#### useAccessToken Hook
+
+This library provides a `useAccessToken` hook for client-side access token management with automatic refresh functionality.
+
+##### Features
+
+- Automatic token refresh before expiration
+- Manual refresh capability
+- Loading and error states
+- Synchronized with the main authentication session
+- Race condition prevention
+
+##### When to Use
+
+Use this hook when you need direct access to the JWT token for:
+
+- Making authenticated API calls
+- Setting up external auth-dependent libraries
+- Implementing custom authentication logic
+
+##### Basic Usage
+
+```jsx
+function ApiClient() {
+  const { accessToken, loading, error, refresh } = useAccessToken();
+  
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!accessToken) return <div>Not authenticated</div>;
+  
+  return (
+    <div>
+      <p>Token available: {accessToken.substring(0, 10)}...</p>
+      <button onClick={refresh}>Refresh token</button>
+    </div>
+  );
+}
+```
+
+##### API Reference
+
+| Property      | Type | Description |
+|---------------|------|-------------|
+| `accessToken`  | `string \| undefined` | The current access token |
+| `loading` | `boolean` | True when token is being fetched or refreshed |
+| `error` | `Error \| null` | Error during token fetch/refresh, or null |
+| `refresh` | `() => Promise<string \| undefined>` | Manually refresh the token |
+
+##### Integration with useAuth
+The `useAccessToken` hook automatically synchronizes with the main authentication session. When you call `refreshAuth()` from `useAuth`, the access token will update accordingly. Similarly, using the `refresh()` method from `useAccessToken` will update the entire authentication session.
+
+##### Security Considerations
+JWT tokens are sensitive credentials and should be handled carefully:
+
+- Only use the token where necessary
+- Don't store tokens in localStorage or sessionStorage
+- Be cautious about exposing tokens in your application state
+
 ### Middleware auth
 
 The default behavior of this library is to request authentication via the `withAuth` method on a per-page basis. There are some use cases where you don't want to call `withAuth` (e.g. you don't need user data for your page) or if you'd prefer a "secure by default" approach where every route defined in your middleware matcher is protected unless specified otherwise. In those cases you can opt-in to use middleware auth instead:

--- a/__tests__/actions.spec.ts
+++ b/__tests__/actions.spec.ts
@@ -5,6 +5,8 @@ import {
   getAuthAction,
   refreshAuthAction,
   switchToOrganizationAction,
+  getAccessTokenAction,
+  refreshAccessTokenAction,
 } from '../src/actions.js';
 import { signOut, switchToOrganization } from '../src/auth.js';
 import { getWorkOS } from '../src/workos.js';
@@ -25,8 +27,8 @@ jest.mock('../src/workos.js', () => ({
 }));
 
 jest.mock('../src/session.js', () => ({
-  withAuth: jest.fn().mockResolvedValue({ user: 'testUser' }),
-  refreshSession: jest.fn().mockResolvedValue({ session: 'newSession' }),
+  withAuth: jest.fn().mockResolvedValue({ user: 'testUser', accessToken: 'access_token' }),
+  refreshSession: jest.fn().mockResolvedValue({ session: 'newSession', accessToken: 'refreshed_token' }),
 }));
 
 describe('actions', () => {
@@ -77,6 +79,22 @@ describe('actions', () => {
       const result = await switchToOrganizationAction('org_123', options);
       expect(switchToOrganization).toHaveBeenCalledWith('org_123', options);
       expect(result).toEqual({ organizationId: 'org_123' });
+    });
+  });
+
+  describe('getAccessTokenAction', () => {
+    it('should return access token', async () => {
+      const result = await getAccessTokenAction();
+      expect(withAuth).toHaveBeenCalled();
+      expect(result).toEqual('access_token');
+    });
+  });
+
+  describe('refreshAccessTokenAction', () => {
+    it('should refresh access token', async () => {
+      const result = await refreshAccessTokenAction();
+      expect(refreshSession).toHaveBeenCalled();
+      expect(result).toEqual('refreshed_token');
     });
   });
 });

--- a/__tests__/useAccessToken.spec.tsx
+++ b/__tests__/useAccessToken.spec.tsx
@@ -1,0 +1,638 @@
+import React from 'react';
+import { render, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useAccessToken } from '../src/components/useAccessToken.js';
+import { getAccessTokenAction, refreshAccessTokenAction } from '../src/actions.js';
+import { useAuth } from '../src/components/authkit-provider.js';
+
+jest.mock('../src/actions.js', () => ({
+  getAccessTokenAction: jest.fn(),
+  refreshAccessTokenAction: jest.fn(),
+}));
+
+jest.mock('../src/components/authkit-provider.js', () => {
+  const originalModule = jest.requireActual('../src/components/authkit-provider.js');
+  return {
+    ...originalModule,
+    useAuth: jest.fn(),
+  };
+});
+
+describe('useAccessToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    (useAuth as jest.Mock).mockImplementation(() => ({
+      user: { id: 'user_123' },
+      sessionId: 'session_123',
+      refreshAuth: jest.fn().mockResolvedValue({}),
+    }));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const TestComponent = () => {
+    const { accessToken, loading, error, refresh } = useAccessToken();
+    return (
+      <div>
+        <div data-testid="token">{accessToken || 'no-token'}</div>
+        <div data-testid="loading">{loading.toString()}</div>
+        <div data-testid="error">{error?.message || 'no-error'}</div>
+        <button data-testid="refresh" onClick={() => refresh()}>
+          Refresh
+        </button>
+      </div>
+    );
+  };
+
+  it('should fetch an access token on mount', async () => {
+    const mockToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwic2lkIjoic2Vzc2lvbl8xMjMiLCJleHAiOjk5OTk5OTk5OTl9.mock-signature';
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(mockToken);
+
+    const { getByTestId } = render(<TestComponent />);
+
+    expect(getByTestId('loading')).toHaveTextContent('true');
+
+    await waitFor(() => {
+      expect(getByTestId('loading')).toHaveTextContent('false');
+      expect(getByTestId('token')).toHaveTextContent(mockToken);
+    });
+
+    expect(getAccessTokenAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle token refresh when an expiring token is received', async () => {
+    // Create a token that's about to expire (exp is very close to current time)
+    const currentTimeInSeconds = Math.floor(Date.now() / 1000);
+    const payload = { sub: '1234567890', sid: 'session_123', exp: currentTimeInSeconds + 30 };
+    const expiringToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${btoa(JSON.stringify(payload))}.mock-signature`;
+
+    const refreshedToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwic2lkIjoic2Vzc2lvbl8xMjMiLCJleHAiOjk5OTk5OTk5OTl9.mock-signature';
+
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(expiringToken);
+    (refreshAccessTokenAction as jest.Mock).mockResolvedValueOnce(refreshedToken);
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('loading')).toHaveTextContent('false');
+      expect(getByTestId('token')).toHaveTextContent(refreshedToken);
+    });
+
+    expect(getAccessTokenAction).toHaveBeenCalledTimes(1);
+    expect(refreshAccessTokenAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle token refresh on manual refresh', async () => {
+    const initialToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwic2lkIjoic2Vzc2lvbl8xMjMiLCJleHAiOjk5OTk5OTk5OTl9.mock-signature';
+    const refreshedToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZWZyZXNoZWQiLCJzaWQiOiJzZXNzaW9uXzEyMyIsImV4cCI6OTk5OTk5OTk5OX0.mock-signature-2';
+
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(initialToken).mockResolvedValueOnce(refreshedToken);
+
+    const mockRefreshAuth = jest.fn().mockResolvedValue({});
+    (useAuth as jest.Mock).mockImplementation(() => ({
+      user: { id: 'user_123' },
+      sessionId: 'session_123',
+      refreshAuth: mockRefreshAuth,
+    }));
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('token')).toHaveTextContent(initialToken);
+    });
+
+    act(() => {
+      getByTestId('refresh').click();
+    });
+
+    await waitFor(() => {
+      expect(mockRefreshAuth).toHaveBeenCalledTimes(1);
+      expect(getAccessTokenAction).toHaveBeenCalledTimes(2);
+      expect(getByTestId('token')).toHaveTextContent(refreshedToken);
+    });
+  });
+
+  it('should schedule automatic token refresh before expiration', async () => {
+    // Create a token that expires in 2 minutes
+    const currentTimeInSeconds = Math.floor(Date.now() / 1000);
+    const expTimeInSeconds = currentTimeInSeconds + 120; // 2 minutes in future
+    const payload = { sub: '1234567890', sid: 'session_123', exp: expTimeInSeconds };
+    const token = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${btoa(JSON.stringify(payload))}.mock-signature`;
+
+    const refreshedToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZWZyZXNoZWQiLCJzaWQiOiJzZXNzaW9uXzEyMyIsImV4cCI6OTk5OTk5OTk5OX0.mock-signature-2';
+
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(token);
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(refreshedToken);
+
+    render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getAccessTokenAction).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime((120 - 60) * 1000);
+    });
+
+    await waitFor(() => {
+      expect(getAccessTokenAction).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('should handle the not loggged in state', async () => {
+    (useAuth as jest.Mock).mockImplementation(() => ({
+      user: undefined,
+      sessionId: undefined,
+      refreshAuth: jest.fn().mockResolvedValue({}),
+    }));
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('loading')).toHaveTextContent('false');
+      expect(getByTestId('token')).toHaveTextContent('no-token');
+    });
+  });
+
+  it('should handle errors during token fetch', async () => {
+    const error = new Error('Failed to fetch token');
+    (getAccessTokenAction as jest.Mock).mockRejectedValueOnce(error);
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('loading')).toHaveTextContent('false');
+      expect(getByTestId('error')).toHaveTextContent('Failed to fetch token');
+      expect(getByTestId('token')).toHaveTextContent('no-token');
+    });
+  });
+
+  it('should handle errors during manual refresh', async () => {
+    const initialToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwic2lkIjoic2Vzc2lvbl8xMjMiLCJleHAiOjk5OTk5OTk5OTl9.mock-signature';
+    const error = new Error('Failed to refresh token');
+
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(initialToken);
+
+    const mockRefreshAuth = jest.fn().mockRejectedValueOnce(error);
+    (useAuth as jest.Mock).mockImplementation(() => ({
+      user: { id: 'user_123' },
+      sessionId: 'session_123',
+      refreshAuth: mockRefreshAuth,
+    }));
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('token')).toHaveTextContent(initialToken);
+    });
+
+    await act(async () => {
+      getByTestId('refresh').click();
+    });
+
+    await waitFor(() => {
+      expect(mockRefreshAuth).toHaveBeenCalledTimes(1);
+      expect(getByTestId('error')).toHaveTextContent('Failed to refresh token');
+    });
+  });
+
+  it('should reset token state when user is undefined', async () => {
+    const mockToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwic2lkIjoic2Vzc2lvbl8xMjMiLCJleHAiOjk5OTk5OTk5OTl9.mock-signature';
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(mockToken);
+
+    // First render with user
+    (useAuth as jest.Mock).mockImplementation(() => ({
+      user: { id: 'user_123' },
+      sessionId: 'session_123',
+      refreshAuth: jest.fn().mockResolvedValue({}),
+    }));
+
+    const { getByTestId, rerender } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('token')).toHaveTextContent(mockToken);
+    });
+
+    (useAuth as jest.Mock).mockImplementation(() => ({
+      user: undefined,
+      sessionId: undefined,
+      refreshAuth: jest.fn().mockResolvedValue({}),
+    }));
+
+    rerender(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('token')).toHaveTextContent('no-token');
+    });
+  });
+
+  it('should handle invalid tokens gracefully', async () => {
+    const invalidToken = 'invalid-token';
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(invalidToken);
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('loading')).toHaveTextContent('false');
+      expect(getByTestId('token')).toHaveTextContent('no-token');
+    });
+  });
+
+  it('should retry fetching when an error occurs', async () => {
+    const error = new Error('Failed to fetch token');
+    const mockToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwic2lkIjoic2Vzc2lvbl8xMjMiLCJleHAiOjk5OTk5OTk5OTl9.mock-signature';
+
+    (getAccessTokenAction as jest.Mock).mockRejectedValueOnce(error).mockResolvedValueOnce(mockToken);
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('error')).toHaveTextContent('Failed to fetch token');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5 * 60 * 1000); // RETRY_DELAY
+    });
+
+    await waitFor(() => {
+      expect(getAccessTokenAction).toHaveBeenCalledTimes(2);
+      expect(getByTestId('token')).toHaveTextContent(mockToken);
+      expect(getByTestId('error')).toHaveTextContent('no-error');
+    });
+  });
+
+  it('should handle errors when refreshing an expiring token', async () => {
+    // Create a token that's about to expire
+    const currentTimeInSeconds = Math.floor(Date.now() / 1000);
+    const payload = { sub: '1234567890', sid: 'session_123', exp: currentTimeInSeconds + 30 };
+    const expiringToken = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${btoa(JSON.stringify(payload))}.mock-signature`;
+    const error = new Error('Failed to refresh token');
+
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(expiringToken);
+    (refreshAccessTokenAction as jest.Mock).mockRejectedValueOnce(error);
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('loading')).toHaveTextContent('false');
+      expect(getByTestId('error')).toHaveTextContent('Failed to refresh token');
+    });
+
+    expect(getAccessTokenAction).toHaveBeenCalledTimes(1);
+    expect(refreshAccessTokenAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle token with an invalid payload format', async () => {
+    const badPayloadToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.invalidpayload.mock-signature';
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(badPayloadToken);
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('loading')).toHaveTextContent('false');
+      expect(getByTestId('token')).toHaveTextContent('no-token');
+    });
+  });
+
+  it('should immediately try to update token when token is undefined', async () => {
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(undefined).mockResolvedValueOnce(undefined);
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('loading')).toHaveTextContent('false');
+      expect(getByTestId('token')).toHaveTextContent('no-token');
+    });
+
+    expect(getAccessTokenAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('should react to sessionId changes', async () => {
+    // Clear any previous mocks to ensure clean state
+    jest.clearAllMocks();
+
+    const token1 = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMSIsImV4cCI6OTk5OTk5OTk5OX0.mock-signature-1';
+    const token2 = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMSIsImV4cCI6OTk5OTk5OTk5OX0.mock-signature-2';
+
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(token1).mockResolvedValueOnce(token2);
+
+    (useAuth as jest.Mock).mockImplementation(() => ({
+      user: { id: 'user1' },
+      sessionId: 'session1',
+      refreshAuth: jest.fn().mockResolvedValue({}),
+    }));
+
+    const { rerender } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getAccessTokenAction).toHaveBeenCalledTimes(1);
+    });
+
+    (useAuth as jest.Mock).mockImplementation(() => ({
+      user: { id: 'user1' }, // Same user ID
+      sessionId: 'session2',
+      refreshAuth: jest.fn().mockResolvedValue({}),
+    }));
+
+    rerender(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getAccessTokenAction).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('should prevent concurrent token fetches via updateToken', async () => {
+    jest.clearAllMocks();
+
+    const mockToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwic2lkIjoic2Vzc2lvbl8xMjMiLCJleHAiOjk5OTk5OTk5OTl9.mock-signature';
+
+    let fetchCalls = 0;
+
+    const tokenPromise = new Promise<string>((resolve) => {
+      setTimeout(() => {
+        resolve(mockToken);
+      }, 0);
+    });
+
+    (getAccessTokenAction as jest.Mock).mockImplementation(() => {
+      fetchCalls++;
+      return tokenPromise;
+    });
+
+    const { getByTestId } = render(<TestComponent />);
+
+    expect(getByTestId('loading')).toHaveTextContent('true');
+
+    await waitFor(() => {
+      expect(fetchCalls).toBe(1);
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('loading')).toHaveTextContent('false');
+      expect(getByTestId('token')).toHaveTextContent(mockToken);
+    });
+
+    expect(fetchCalls).toBe(1);
+  });
+
+  it('should prevent concurrent manual refresh operations', async () => {
+    jest.clearAllMocks();
+
+    let refreshAuthCalls = 0;
+
+    const mockToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwic2lkIjoic2Vzc2lvbl8xMjMiLCJleHAiOjk5OTk5OTk5OTl9.mock-signature';
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const refreshAuthPromise = new Promise<any>((resolve) => {
+      // Slow promise
+      setTimeout(() => resolve({}), 10);
+    });
+
+    const mockRefreshAuth = jest.fn().mockImplementation(() => {
+      refreshAuthCalls++;
+      return refreshAuthPromise;
+    });
+
+    (useAuth as jest.Mock).mockImplementation(() => ({
+      user: { id: 'user_123' },
+      sessionId: 'session_123',
+      refreshAuth: mockRefreshAuth,
+    }));
+
+    (getAccessTokenAction as jest.Mock).mockImplementation(() => {
+      return Promise.resolve(mockToken);
+    });
+
+    const { getByTestId } = render(<TestComponent />);
+
+    // Wait for initial token
+    await waitFor(() => {
+      expect(getByTestId('token')).toHaveTextContent(mockToken);
+    });
+
+    // Call refresh twice in succession - should only result in one actual refresh call
+    act(() => {
+      getByTestId('refresh').click();
+      getByTestId('refresh').click();
+    });
+
+    // Wait for refresh to complete
+    await waitFor(() => {
+      expect(refreshAuthCalls).toBe(1);
+    });
+
+    // Verify that refreshAuth was only called once despite two clicks
+    expect(refreshAuthCalls).toBe(1);
+  });
+
+  it('should handle non-Error objects thrown during token fetch', async () => {
+    // Simulate a string error being thrown
+    (getAccessTokenAction as jest.Mock).mockImplementation(() => {
+      throw 'String error message';
+    });
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('loading')).toHaveTextContent('false');
+      expect(getByTestId('error')).toHaveTextContent('String error message');
+    });
+  });
+
+  // Additional test cases to increase coverage
+  it('should handle concurrent manual refresh attempts', async () => {
+    const initialToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwic2lkIjoic2Vzc2lvbl8xMjMiLCJleHAiOjk5OTk5OTk5OTl9.mock-signature';
+    const refreshedToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZWZyZXNoZWQiLCJzaWQiOiJzZXNzaW9uXzEyMyIsImV4cCI6OTk5OTk5OTk5OX0.mock-signature-2';
+
+    // Setup a delayed promise for the refresh auth
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let resolveRefreshPromise: (value: any) => void;
+    const refreshPromise = new Promise((resolve) => {
+      resolveRefreshPromise = resolve;
+    });
+
+    const mockRefreshAuth = jest.fn().mockReturnValue(refreshPromise);
+    (useAuth as jest.Mock).mockImplementation(() => ({
+      user: { id: 'user_123' },
+      sessionId: 'session_123',
+      refreshAuth: mockRefreshAuth,
+    }));
+
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(initialToken).mockResolvedValueOnce(refreshedToken);
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('token')).toHaveTextContent(initialToken);
+    });
+
+    act(() => {
+      getByTestId('refresh').click();
+    });
+
+    act(() => {
+      getByTestId('refresh').click();
+    });
+
+    act(() => {
+      resolveRefreshPromise!({});
+    });
+
+    await waitFor(() => {
+      expect(mockRefreshAuth).toHaveBeenCalledTimes(1); // Should only call once
+      expect(getAccessTokenAction).toHaveBeenCalledTimes(2);
+      expect(getByTestId('token')).toHaveTextContent(refreshedToken);
+    });
+  });
+
+  it('should handle errors during token refresh when autoRefresh is scheduled', async () => {
+    // Create a token that expires in 2 minutes
+    const currentTimeInSeconds = Math.floor(Date.now() / 1000);
+    const expTimeInSeconds = currentTimeInSeconds + 120; // 2 minutes in future
+    const payload = { sub: '1234567890', sid: 'session_123', exp: expTimeInSeconds };
+    const token = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${btoa(JSON.stringify(payload))}.mock-signature`;
+
+    const error = new Error('Failed to refresh token');
+
+    (getAccessTokenAction as jest.Mock)
+      .mockResolvedValueOnce(token) // Initial fetch succeeds
+      .mockRejectedValueOnce(error); // But auto-refresh fails
+
+    render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getAccessTokenAction).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime((120 - 60) * 1000);
+    });
+
+    await waitFor(() => {
+      expect(getAccessTokenAction).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('should clear refresh timeout on unmount', async () => {
+    const mockToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwic2lkIjoic2Vzc2lvbl8xMjMiLCJleHAiOjk5OTk5OTk5OTl9.mock-signature';
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(mockToken);
+
+    const { getByTestId, unmount } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('token')).toHaveTextContent(mockToken);
+    });
+
+    unmount();
+  });
+
+  it('should handle edge cases when token data is null', async () => {
+    // Create a token that resembles a JWT but with a null payload
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.bnVsbA==.mock-signature'; // "null" in base64
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(token);
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('loading')).toHaveTextContent('false');
+    });
+
+    expect(getByTestId('token')).toHaveTextContent('no-token');
+  });
+
+  it('should handle errors with string messages instead of Error objects', async () => {
+    const error = 'String error message';
+    const errorObj = new Error(error);
+    (getAccessTokenAction as jest.Mock).mockRejectedValueOnce(errorObj);
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('loading')).toHaveTextContent('false');
+      expect(getByTestId('error')).toHaveTextContent(error);
+    });
+  });
+
+  it('should handle string errors during manual refresh', async () => {
+    const initialToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwic2lkIjoic2Vzc2lvbl8xMjMiLCJleHAiOjk5OTk5OTk5OTl9.mock-signature';
+    const stringError = 'String error directly'; // Not wrapped in Error object
+
+    (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(initialToken);
+
+    // Mock refreshAuth to reject with a string, not an Error object
+    const mockRefreshAuth = jest.fn().mockImplementation(() => {
+      return Promise.reject(stringError); // Directly reject with string
+    });
+
+    (useAuth as jest.Mock).mockImplementation(() => ({
+      user: { id: 'user_123' },
+      sessionId: 'session_123',
+      refreshAuth: mockRefreshAuth,
+    }));
+
+    const { getByTestId } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('token')).toHaveTextContent(initialToken);
+    });
+
+    act(() => {
+      getByTestId('refresh').click();
+    });
+
+    await waitFor(() => {
+      expect(mockRefreshAuth).toHaveBeenCalledTimes(1);
+      expect(getByTestId('error')).toHaveTextContent(stringError);
+    });
+  });
+
+  it('should bypass refresh when token is unchanged but user or sessionId changed', async () => {
+    const token =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwic2lkIjoic2Vzc2lvbl8xMjMiLCJleHAiOjk5OTk5OTk5OTl9.mock-signature';
+
+    (getAccessTokenAction as jest.Mock).mockResolvedValue(token);
+
+    (useAuth as jest.Mock).mockImplementation(() => ({
+      user: { id: 'user_123' },
+      sessionId: 'session_123',
+      refreshAuth: jest.fn().mockResolvedValue({}),
+    }));
+
+    const { getByTestId, rerender } = render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getByTestId('token')).toHaveTextContent(token);
+      expect(getAccessTokenAction).toHaveBeenCalledTimes(1);
+    });
+
+    (useAuth as jest.Mock).mockImplementation(() => ({
+      user: { id: 'user_456' }, // Different user
+      sessionId: 'session_123', // Same session
+      refreshAuth: jest.fn().mockResolvedValue({}),
+    }));
+
+    rerender(<TestComponent />);
+
+    await waitFor(() => {
+      expect(getAccessTokenAction).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -51,3 +51,21 @@ export const refreshAuthAction = async ({
 export const switchToOrganizationAction = async (organizationId: string, options?: SwitchToOrganizationOptions) => {
   return sanitize(await switchToOrganization(organizationId, options));
 };
+
+/**
+ * This action is used to get the access token from the auth object.
+ * It is used to fetch the access token from the server.
+ */
+export async function getAccessTokenAction() {
+  const auth = await withAuth();
+  return auth.accessToken;
+}
+
+/**
+ * This action is used to refresh the access token from the auth object.
+ * It is used to fetch the access token from the server.
+ */
+export async function refreshAccessTokenAction() {
+  const auth = await refreshSession();
+  return auth.accessToken;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 import { Impersonation } from './impersonation.js';
 import { AuthKitProvider, useAuth } from './authkit-provider.js';
+import { useAccessToken } from './useAccessToken.js';
 
-export { Impersonation, AuthKitProvider, useAuth };
+export { Impersonation, AuthKitProvider, useAuth, useAccessToken };

--- a/src/components/useAccessToken.ts
+++ b/src/components/useAccessToken.ts
@@ -27,12 +27,14 @@ function tokenReducer(state: TokenState, action: TokenAction): TokenState {
       return { ...state, loading: false, error: action.error };
     case 'RESET':
       return { ...state, token: undefined, loading: false, error: null };
+    // istanbul ignore next
     default:
       return state;
   }
 }
 
 function parseToken(token: string | undefined) {
+  // istanbul ignore next
   if (!token) {
     return null;
   }
@@ -53,6 +55,7 @@ function parseToken(token: string | undefined) {
       timeUntilExpiry: payload.exp - now,
     };
   } catch {
+    // istanbul ignore next
     return null;
   }
 }
@@ -122,15 +125,11 @@ export function useAccessToken() {
     dispatch({ type: 'FETCH_START' });
 
     try {
-      // First refresh the overall auth session
       await refreshAuth();
-
-      // Then get the fresh token
       const token = await getAccessTokenAction();
 
       dispatch({ type: 'FETCH_SUCCESS', token });
 
-      // Set up a refresh timer if we got a valid token
       if (token) {
         const tokenData = parseToken(token);
         if (tokenData) {
@@ -145,7 +144,6 @@ export function useAccessToken() {
       const typedError = error instanceof Error ? error : new Error(String(error));
       dispatch({ type: 'FETCH_ERROR', error: typedError });
       refreshTimeoutRef.current = setTimeout(updateToken, RETRY_DELAY);
-      throw typedError;
     } finally {
       fetchingRef.current = false;
     }

--- a/src/components/useAccessToken.ts
+++ b/src/components/useAccessToken.ts
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+import { getAccessTokenAction, refreshAccessTokenAction } from '../actions.js';
+import { useAuth } from './authkit-provider.js';
+
+const TOKEN_EXPIRY_BUFFER_SECONDS = 60;
+const RETRY_DELAY = 5 * 60 * 1000;
+
+interface TokenState {
+  token: string | undefined;
+  loading: boolean;
+  error: Error | null;
+}
+
+type TokenAction =
+  | { type: 'FETCH_START' }
+  | { type: 'FETCH_SUCCESS'; token: string | undefined }
+  | { type: 'FETCH_ERROR'; error: Error }
+  | { type: 'RESET' };
+
+function tokenReducer(state: TokenState, action: TokenAction): TokenState {
+  switch (action.type) {
+    case 'FETCH_START':
+      return { ...state, loading: true, error: null };
+    case 'FETCH_SUCCESS':
+      return { ...state, loading: false, token: action.token };
+    case 'FETCH_ERROR':
+      return { ...state, loading: false, error: action.error };
+    case 'RESET':
+      return { ...state, token: undefined, loading: false, error: null };
+    default:
+      return state;
+  }
+}
+
+function parseToken(token: string | undefined) {
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return null;
+    }
+
+    const payload = JSON.parse(atob(parts[1]));
+    const now = Math.floor(Date.now() / 1000);
+
+    return {
+      payload,
+      expiresAt: payload.exp,
+      isExpiring: payload.exp < now + TOKEN_EXPIRY_BUFFER_SECONDS,
+      timeUntilExpiry: payload.exp - now,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A hook that manages access tokens with automatic refresh.
+ */
+export function useAccessToken() {
+  const { user, sessionId, refreshAuth } = useAuth();
+  const userId = user?.id;
+  const [state, dispatch] = useReducer(tokenReducer, {
+    token: undefined,
+    loading: false,
+    error: null,
+  });
+
+  const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const fetchingRef = useRef(false);
+
+  const clearRefreshTimeout = useCallback(() => {
+    if (refreshTimeoutRef.current) {
+      clearTimeout(refreshTimeoutRef.current);
+      refreshTimeoutRef.current = undefined;
+    }
+  }, []);
+
+  const updateToken = useCallback(async () => {
+    if (fetchingRef.current) {
+      return;
+    }
+
+    fetchingRef.current = true;
+    dispatch({ type: 'FETCH_START' });
+    try {
+      let token = await getAccessTokenAction();
+      if (token) {
+        const tokenData = parseToken(token);
+        if (!tokenData || tokenData.isExpiring) {
+          token = await refreshAccessTokenAction();
+        }
+      }
+
+      dispatch({ type: 'FETCH_SUCCESS', token });
+
+      if (token) {
+        const tokenData = parseToken(token);
+        if (tokenData) {
+          const delay = Math.max((tokenData.timeUntilExpiry - TOKEN_EXPIRY_BUFFER_SECONDS) * 1000, 0);
+          clearRefreshTimeout();
+          refreshTimeoutRef.current = setTimeout(updateToken, delay);
+        }
+      }
+
+      return token;
+    } catch (error) {
+      dispatch({ type: 'FETCH_ERROR', error: error instanceof Error ? error : new Error(String(error)) });
+      refreshTimeoutRef.current = setTimeout(updateToken, RETRY_DELAY);
+    } finally {
+      fetchingRef.current = false;
+    }
+  }, [clearRefreshTimeout]);
+
+  const refresh = useCallback(async () => {
+    if (fetchingRef.current) return;
+
+    fetchingRef.current = true;
+    dispatch({ type: 'FETCH_START' });
+
+    try {
+      // First refresh the overall auth session
+      await refreshAuth();
+
+      // Then get the fresh token
+      const token = await getAccessTokenAction();
+
+      dispatch({ type: 'FETCH_SUCCESS', token });
+
+      // Set up a refresh timer if we got a valid token
+      if (token) {
+        const tokenData = parseToken(token);
+        if (tokenData) {
+          const delay = Math.max((tokenData.timeUntilExpiry - TOKEN_EXPIRY_BUFFER_SECONDS) * 1000, 0);
+          clearRefreshTimeout();
+          refreshTimeoutRef.current = setTimeout(updateToken, delay);
+        }
+      }
+
+      return token;
+    } catch (error) {
+      const typedError = error instanceof Error ? error : new Error(String(error));
+      dispatch({ type: 'FETCH_ERROR', error: typedError });
+      refreshTimeoutRef.current = setTimeout(updateToken, RETRY_DELAY);
+      throw typedError;
+    } finally {
+      fetchingRef.current = false;
+    }
+  }, [refreshAuth, clearRefreshTimeout, updateToken]);
+
+  useEffect(() => {
+    if (!user) {
+      dispatch({ type: 'RESET' });
+      clearRefreshTimeout();
+      return;
+    }
+    updateToken();
+
+    return clearRefreshTimeout;
+  }, [userId, sessionId, updateToken, clearRefreshTimeout]);
+
+  return {
+    accessToken: state.token,
+    loading: state.loading,
+    error: state.error,
+    refresh,
+  };
+}


### PR DESCRIPTION
This pull request introduces a new feature for managing access tokens with automatic refresh functionality. The most important changes include the addition of a `useAccessToken` hook, updates to the actions and tests to support access token retrieval and refresh, and integration of the new hook into the components.

### New Feature: Access Token Management

* **New `useAccessToken` Hook**: A hook for client-side access token management with automatic refresh functionality. It includes features such as automatic token refresh, manual refresh capability, loading and error states, synchronization with the main authentication session, and race condition prevention. (`README.md`, `src/components/useAccessToken.ts`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R287-R346) [[2]](diffhunk://#diff-f61f730c00da3e02df4c20f141da8da983a8202cf5a86c8b6caeaf72905b23fbR1-R171)

### Actions and Tests Updates

* **New Actions**: Added `getAccessTokenAction` and `refreshAccessTokenAction` to fetch and refresh access tokens from the server. (`src/actions.ts`)
* **Test Updates**: Updated tests to mock access token retrieval and refresh, and added tests for the new actions. (`__tests__/actions.spec.ts`) [[1]](diffhunk://#diff-0d3ad5dd1866db46168a19e4501aa30548e56c7a839a6f8ace97185599af5fd7R8-R9) [[2]](diffhunk://#diff-0d3ad5dd1866db46168a19e4501aa30548e56c7a839a6f8ace97185599af5fd7L28-R31) [[3]](diffhunk://#diff-0d3ad5dd1866db46168a19e4501aa30548e56c7a839a6f8ace97185599af5fd7R84-R99)

### Component Integration

* **Export `useAccessToken`**: Exported the new `useAccessToken` hook from the components index file. (`src/components/index.ts`)