### PR TITLE
Add session refresh callbacks to updateSession function

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -76,6 +76,12 @@ export interface AuthkitOptions {
   debug?: boolean;
   redirectUri?: string;
   screenHint?: 'sign-up' | 'sign-in';
+  onSessionRefreshSuccess?: (data: {
+    accessToken: string;
+    user: User;
+    impersonator?: Impersonator;
+  }) => void | Promise<void>;
+  onSessionRefreshError?: (params: { error?: unknown; request: NextRequest }) => void | Promise<void>;
 }
 
 export interface AuthkitResponse {

--- a/src/session.ts
+++ b/src/session.ts
@@ -219,6 +219,8 @@ async function updateSession(
       entitlements,
     } = decodeJwt<AccessToken>(accessToken);
 
+    options.onSessionRefreshSuccess?.({ accessToken, user, impersonator });
+
     return {
       session: {
         sessionId,
@@ -240,6 +242,8 @@ async function updateSession(
     // When we need to delete a cookie, return it as a header as you can't delete cookies from edge middleware
     const deleteCookie = `${cookieName}=; Expires=${new Date(0).toUTCString()}; ${getCookieOptions(request.url, true, true)}`;
     newRequestHeaders.append('Set-Cookie', deleteCookie);
+
+    options.onSessionRefreshError?.({ error: e, request });
 
     return {
       session: { user: null },


### PR DESCRIPTION
This pull request introduces new callback functions to handle session refresh success and failure events in the `session.ts` module. The primary changes include adding tests to verify these callbacks and updating the `AuthkitOptions` interface to support the new callbacks.

- Updated `AuthkitOptions` interface to include the new callback types.
- Added tests to verify the correct invocation of these callbacks during session refresh success and failure scenarios.

### New callback functions for session refresh events:

* [`__tests__/session.spec.ts`](diffhunk://#diff-760832a03a426e899a6012a4243bc1404d0c0c41aba0a0344cc25177c5b1cc58R689-R759): Added tests to verify that the `onSessionRefreshSuccess` and `onSessionRefreshError` callbacks are called appropriately during session refresh.
* [`src/interfaces.ts`](diffhunk://#diff-2ee8da4ec0f3c043c7e097851af07383ae3ce13022973c8727312e06bf2b89b3R79-R84): Updated the `AuthkitOptions` interface to include `onSessionRefreshSuccess` and `onSessionRefreshError` callbacks.

### Session update logic:

* [`src/session.ts`](diffhunk://#diff-96998a2148aa3d52ad3e80303d0ad88fc43a4afd08966b5330a5657021ae52bbR222-R223): Modified the `updateSession` function to call `onSessionRefreshSuccess` when the session refresh succeeds.
* [`src/session.ts`](diffhunk://#diff-96998a2148aa3d52ad3e80303d0ad88fc43a4afd08966b5330a5657021ae52bbR246-R247): Modified the `updateSession` function to call `onSessionRefreshError` when the session refresh fails.- Implemented onSessionRefreshSuccess and onSessionRefreshError options in the updateSession function to handle session refresh outcomes.
