### PR TITLE
Fix errors thrown by signOut method

### DIFF
--- a/__tests__/session.spec.ts
+++ b/__tests__/session.spec.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { generateTestToken } from './test-helpers.js';
-import { withAuth, updateSession, refreshSession, terminateSession, updateSessionMiddleware } from '../src/session.js';
+import { withAuth, updateSession, refreshSession, updateSessionMiddleware } from '../src/session.js';
 import { getWorkOS } from '../src/workos.js';
 import * as envVariables from '../src/env-variables.js';
 
@@ -840,59 +840,6 @@ describe('session.ts', () => {
       );
       jest.spyOn(workos.userManagement, 'authenticateWithRefreshToken').mockRejectedValue(new Error('error'));
       expect(refreshSession()).rejects.toThrow('error');
-    });
-  });
-
-  describe('terminateSession', () => {
-    it('should redirect to logout url when there is a session', async () => {
-      const nextHeaders = await headers();
-      nextHeaders.set('x-url', 'http://example.com/protected');
-
-      mockSession.accessToken = await generateTestToken();
-
-      nextHeaders.set(
-        'x-workos-session',
-        await sealData(mockSession, { password: process.env.WORKOS_COOKIE_PASSWORD as string }),
-      );
-
-      await terminateSession();
-
-      expect(redirect).toHaveBeenCalledTimes(1);
-      expect(redirect).toHaveBeenCalledWith(
-        'https://api.workos.com/user_management/sessions/logout?session_id=session_123',
-      );
-    });
-
-    it('should redirect to home when there is no session', async () => {
-      const nextHeaders = await headers();
-      nextHeaders.set('x-url', 'http://example.com/protected');
-
-      await terminateSession();
-      expect(redirect).toHaveBeenCalledWith('/');
-
-      await terminateSession({ returnTo: '/foo' });
-      expect(redirect).toHaveBeenCalledWith('/foo');
-    });
-
-    describe('when given a `returnTo` URL', () => {
-      it('includes a `return_to` query parameter in the logout URL', async () => {
-        const nextHeaders = await headers();
-        nextHeaders.set('x-url', 'http://example.com/protected');
-
-        mockSession.accessToken = await generateTestToken();
-
-        nextHeaders.set(
-          'x-workos-session',
-          await sealData(mockSession, { password: process.env.WORKOS_COOKIE_PASSWORD as string }),
-        );
-
-        await terminateSession({ returnTo: 'http://example.com/signed-out' });
-
-        expect(redirect).toHaveBeenCalledTimes(1);
-        expect(redirect).toHaveBeenCalledWith(
-          'https://api.workos.com/user_management/sessions/logout?session_id=session_123&return_to=http%3A%2F%2Fexample.com%2Fsigned-out',
-        );
-      });
     });
   });
 });

--- a/src/session.ts
+++ b/src/session.ts
@@ -386,15 +386,6 @@ async function withAuth(options?: { ensureSignedIn?: boolean }): Promise<UserInf
   };
 }
 
-async function terminateSession({ returnTo }: { returnTo?: string } = {}) {
-  const { sessionId } = await withAuth();
-  if (sessionId) {
-    redirect(getWorkOS().userManagement.getLogoutUrl({ sessionId, returnTo }));
-  } else {
-    redirect(returnTo ?? '/');
-  }
-}
-
 async function verifyAccessToken(accessToken: string) {
   try {
     await jwtVerify(accessToken, JWKS());
@@ -495,4 +486,4 @@ export async function saveSession(
   nextCookies.set(cookieName, encryptedSession, getCookieOptions(url));
 }
 
-export { encryptSession, refreshSession, terminateSession, updateSession, updateSessionMiddleware, withAuth };
+export { encryptSession, refreshSession, updateSession, updateSessionMiddleware, withAuth };


### PR DESCRIPTION
Improve robustness of `signOut` method by:

- not calling `getCookieOptions` (the only options that may be needed are `path` and `domain`)
- remove call to `terminateSession` which would call `withAuth` after the cookie is deleted
- remove `terminateSession` method as it's no longer called by anything
- tests

Fixes #242 