### PR TITLE
fix: infinite redirects when using useAccessToken with 60 second token duration

### DIFF
--- a/src/components/useAccessToken.ts
+++ b/src/components/useAccessToken.ts
@@ -3,6 +3,7 @@ import { getAccessTokenAction, refreshAccessTokenAction } from '../actions.js';
 import { useAuth } from './authkit-provider.js';
 
 const TOKEN_EXPIRY_BUFFER_SECONDS = 60;
+const MIN_REFRESH_DELAY = 15_000; // minimum delay before refreshing token
 const RETRY_DELAY = 5 * 60 * 1000;
 
 interface TokenState {
@@ -103,7 +104,7 @@ export function useAccessToken() {
       if (token) {
         const tokenData = parseToken(token);
         if (tokenData) {
-          const delay = Math.max((tokenData.timeUntilExpiry - TOKEN_EXPIRY_BUFFER_SECONDS) * 1000, 0);
+          const delay = Math.max((tokenData.timeUntilExpiry - TOKEN_EXPIRY_BUFFER_SECONDS) * 1000, MIN_REFRESH_DELAY);
           clearRefreshTimeout();
           refreshTimeoutRef.current = setTimeout(updateToken, delay);
         }
@@ -133,7 +134,7 @@ export function useAccessToken() {
       if (token) {
         const tokenData = parseToken(token);
         if (tokenData) {
-          const delay = Math.max((tokenData.timeUntilExpiry - TOKEN_EXPIRY_BUFFER_SECONDS) * 1000, 0);
+          const delay = Math.max((tokenData.timeUntilExpiry - TOKEN_EXPIRY_BUFFER_SECONDS) * 1000, MIN_REFRESH_DELAY);
           clearRefreshTimeout();
           refreshTimeoutRef.current = setTimeout(updateToken, delay);
         }


### PR DESCRIPTION
This change fixes an issue where the `useAccessToken` hook would cause infinite requests to the server when using tokens with a 60-second duration.

The problem:
- The token expiry buffer was set to 60 seconds
- When token lifetime matched this buffer exactly (60 seconds)
- Calculated delay was (expiry - buffer) = 0 seconds
- This triggered immediate refresh attempts in a loop

The fix:
- Added a minimum refresh delay of 15 seconds
- This prevents rapid refresh cycles even when calculations result in zero
- Applied in both updateToken and refresh functions
- Provides protection against token duration changes or clock issues