### PR TITLE
feat: add organizationId to onSuccess callback args and saveSession args

### DIFF
--- a/__tests__/authkit-callback-route.spec.ts
+++ b/__tests__/authkit-callback-route.spec.ts
@@ -33,6 +33,7 @@ describe('authkit-callback-route', () => {
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z',
     },
+    organizationId: 'org_123',
     oauthTokens: {
       accessToken: 'access123',
       refreshToken: 'refresh123',

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -25,7 +25,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
     if (code) {
       try {
         // Use the code returned to us by AuthKit and authenticate the user with WorkOS
-        const { accessToken, refreshToken, user, impersonator, oauthTokens } =
+        const { accessToken, refreshToken, user, organizationId, impersonator, oauthTokens } =
           await getWorkOS().userManagement.authenticateWithCode({
             clientId: WORKOS_CLIENT_ID,
             code,
@@ -62,10 +62,10 @@ export function handleAuth(options: HandleAuthOptions = {}) {
         if (!accessToken || !refreshToken) throw new Error('response is missing tokens');
 
         if (onSuccess) {
-          await onSuccess({ accessToken, refreshToken, user, impersonator, oauthTokens });
+          await onSuccess({ accessToken, refreshToken, user, organizationId, impersonator, oauthTokens });
         }
 
-        await saveSession({ accessToken, refreshToken, user, impersonator }, request);
+        await saveSession({ accessToken, refreshToken, user, organizationId, impersonator }, request);
 
         return response;
       } catch (error) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,6 +20,7 @@ export interface Session {
   accessToken: string;
   refreshToken: string;
   user: User;
+  organizationId?: string;
   impersonator?: Impersonator;
 }
 


### PR DESCRIPTION
This pull request introduces support for `organizationId` in the `handleAuth` flow. 
The changes makes `organizationId` available in success callback and session state.

### Authentication flow updates:

* [`src/authkit-callback-route.ts`](diffhunk://#diff-efd39b00e6529b9fb945427243d984f524bd72ff6e0f6cdfadacf25ef3c3a3acL28-R28): Updated the `handleAuth` function to include `organizationId` in the destructured response from `authenticateWithCode`. It is now passed to both the `onSuccess` callback and the `saveSession` function.

### Session interface update:

* [`src/interfaces.ts`](diffhunk://#diff-2ee8da4ec0f3c043c7e097851af07383ae3ce13022973c8727312e06bf2b89b3R23): Added an optional `organizationId` field to the `Session` interface to support storing the organization identifier.