### PR TITLE
Consistently pass `redirectUri` to `getAuthorizationUrl` in middleware

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -250,6 +250,7 @@ async function updateSession(
       headers: newRequestHeaders,
       authorizationUrl: await getAuthorizationUrl({
         returnPathname: getReturnPathname(request.url),
+        redirectUri: options.redirectUri || WORKOS_REDIRECT_URI,
       }),
     };
   }


### PR DESCRIPTION
It looks like there's a case where the `getAuthorizationUrl` call below would not have a populated `redirect_uri` parameter in the resulting parameter due to the following:

1. The app has no `NEXT_PUBLIC_WORKOS_REDIRECT_URI`
2. [`x-redirect-rui` is set on the new headers from `options`](https://github.com/workos/authkit-nextjs/blob/4dd9aa28915300ca426faefbb9872fe5afb99e7f/src/session.ts#L132), but that isn't readable from the current headers (`headers()`).

Seems like one thing is missing is making the `getAuthorizationUrl` call below [match the one earlier in the `updateSession` function](https://github.com/workos/authkit-nextjs/blob/4dd9aa28915300ca426faefbb9872fe5afb99e7f/src/session.ts#L147).