### PR TITLE
Add support for the `feature_flags` claim

### DIFF
--- a/__tests__/authkit-provider.spec.tsx
+++ b/__tests__/authkit-provider.spec.tsx
@@ -225,6 +225,7 @@ describe('useAuth', () => {
       role: 'admin',
       permissions: ['read', 'write'],
       entitlements: ['feature1'],
+      featureFlags: ['test-flag'],
       impersonator: { email: 'admin@example.com' },
     });
 

--- a/__tests__/session.spec.ts
+++ b/__tests__/session.spec.ts
@@ -31,6 +31,7 @@ describe('session.ts', () => {
     role: 'member',
     permissions: ['posts:create', 'posts:delete'],
     entitlements: ['audit-logs'],
+    featureFlags: ['device-authorization-grant'],
     impersonator: undefined,
     user: {
       object: 'user',
@@ -858,6 +859,7 @@ describe('session.ts', () => {
         role: 'admin',
         permissions: ['read', 'write'],
         entitlements: ['feature_a'],
+        feature_flags: ['device-authorization-grant'],
         department: 'engineering',
         level: 5,
         metadata: { theme: 'dark' },
@@ -882,6 +884,7 @@ describe('session.ts', () => {
         role: 'admin',
         permissions: ['read', 'write'],
         entitlements: ['feature_a'],
+        feature_flags: ['device-authorization-grant'],
       };
       const token = await generateTestToken(tokenPayload);
 
@@ -903,6 +906,7 @@ describe('session.ts', () => {
         role: 'admin',
         permissions: ['read', 'write'],
         entitlements: ['feature_a'],
+        feature_flags: ['device-authorization-grant'],
         jti: 'jwt_123',
       };
       const token = await generateTestToken({ ...standardClaims, ...customClaims });

--- a/__tests__/test-helpers.ts
+++ b/__tests__/test-helpers.ts
@@ -13,6 +13,7 @@ export async function generateTestToken(payload = {}, expired = false) {
     role: 'member',
     permissions: ['posts:create', 'posts:delete'],
     entitlements: ['audit-logs'],
+    feature_flags: ['device-authorization-grant'],
   };
 
   const mergedPayload = { ...defaultPayload, ...payload };

--- a/__tests__/useTokenClaims.spec.tsx
+++ b/__tests__/useTokenClaims.spec.tsx
@@ -90,6 +90,7 @@ describe('useTokenClaims', () => {
       role: 'admin',
       permissions: ['read', 'write'],
       entitlements: ['feature_a'],
+      feature_flags: ['device-authorization-grant'],
       jti: 'jwt_123',
       nbf: 1234567800,
       // Custom claims
@@ -120,6 +121,7 @@ describe('useTokenClaims', () => {
       role: 'admin',
       permissions: ['read', 'write'],
       entitlements: ['feature_a'],
+      feature_flags: ['device-authorization-grant'],
       jti: 'jwt_123',
       nbf: 1234567800,
     };

--- a/src/components/authkit-provider.tsx
+++ b/src/components/authkit-provider.tsx
@@ -18,6 +18,7 @@ type AuthContextType = {
   role: string | undefined;
   permissions: string[] | undefined;
   entitlements: string[] | undefined;
+  featureFlags: string[] | undefined;
   impersonator: Impersonator | undefined;
   loading: boolean;
   getAuth: (options?: { ensureSignedIn?: boolean }) => Promise<void>;
@@ -47,6 +48,7 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
   const [role, setRole] = useState<string | undefined>(undefined);
   const [permissions, setPermissions] = useState<string[] | undefined>(undefined);
   const [entitlements, setEntitlements] = useState<string[] | undefined>(undefined);
+  const [featureFlags, setFeatureFlags] = useState<string[] | undefined>(undefined);
   const [impersonator, setImpersonator] = useState<Impersonator | undefined>(undefined);
   const [loading, setLoading] = useState(true);
 
@@ -60,6 +62,7 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
       setRole(auth.role);
       setPermissions(auth.permissions);
       setEntitlements(auth.entitlements);
+      setFeatureFlags(auth.featureFlags);
       setImpersonator(auth.impersonator);
     } catch (error) {
       setUser(null);
@@ -68,6 +71,7 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
       setRole(undefined);
       setPermissions(undefined);
       setEntitlements(undefined);
+      setFeatureFlags(undefined);
       setImpersonator(undefined);
     } finally {
       setLoading(false);
@@ -102,6 +106,7 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
       setRole(auth.role);
       setPermissions(auth.permissions);
       setEntitlements(auth.entitlements);
+      setFeatureFlags(auth.featureFlags);
       setImpersonator(auth.impersonator);
     } catch (error) {
       return error instanceof Error ? { error: error.message } : { error: String(error) };
@@ -174,6 +179,7 @@ export const AuthKitProvider = ({ children, onSessionExpired }: AuthKitProviderP
         role,
         permissions,
         entitlements,
+        featureFlags,
         impersonator,
         loading,
         getAuth,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -32,6 +32,7 @@ export interface UserInfo {
   role?: string;
   permissions?: string[];
   entitlements?: string[];
+  featureFlags?: string[];
   impersonator?: Impersonator;
   accessToken: string;
 }
@@ -42,6 +43,7 @@ export interface NoUserInfo {
   role?: undefined;
   permissions?: undefined;
   entitlements?: undefined;
+  featureFlags?: undefined;
   impersonator?: undefined;
   accessToken?: undefined;
 }
@@ -52,6 +54,7 @@ export interface AccessToken {
   role?: string;
   permissions?: string[];
   entitlements?: string[];
+  feature_flags?: string[];
 }
 
 export interface GetAuthURLOptions {

--- a/src/session.ts
+++ b/src/session.ts
@@ -163,6 +163,7 @@ async function updateSession(
       role,
       permissions,
       entitlements,
+      feature_flags: featureFlags,
     } = decodeJwt<AccessToken>(session.accessToken);
 
     return {
@@ -173,6 +174,7 @@ async function updateSession(
         role,
         permissions,
         entitlements,
+        featureFlags,
         impersonator: session.impersonator,
         accessToken: session.accessToken,
       },
@@ -217,6 +219,7 @@ async function updateSession(
       role,
       permissions,
       entitlements,
+      feature_flags: featureFlags,
     } = decodeJwt<AccessToken>(accessToken);
 
     options.onSessionRefreshSuccess?.({ accessToken, user, impersonator, organizationId });
@@ -229,6 +232,7 @@ async function updateSession(
         role,
         permissions,
         entitlements,
+        featureFlags,
         impersonator,
         accessToken,
       },
@@ -305,6 +309,7 @@ async function refreshSession({
     role,
     permissions,
     entitlements,
+    feature_flags: featureFlags,
   } = decodeJwt<AccessToken>(accessToken);
 
   return {
@@ -314,6 +319,7 @@ async function refreshSession({
     role,
     permissions,
     entitlements,
+    featureFlags,
     impersonator,
     accessToken,
   };
@@ -384,6 +390,7 @@ async function withAuth(options?: { ensureSignedIn?: boolean }): Promise<UserInf
     role,
     permissions,
     entitlements,
+    feature_flags: featureFlags,
   } = decodeJwt<AccessToken>(session.accessToken);
 
   return {
@@ -393,6 +400,7 @@ async function withAuth(options?: { ensureSignedIn?: boolean }): Promise<UserInf
     role,
     permissions,
     entitlements,
+    featureFlags,
     impersonator: session.impersonator,
     accessToken: session.accessToken,
   };


### PR DESCRIPTION
Add support for the `feature_flags` claim. This claim will be exposed on the session as `featureFlags` and will contain a list of the string slugs for feature flags that are enabled for the current user session based on organization membership.
```ts
const { featureFlags } = newSession;
if (featureFlags.includes('my_flag')) {
   // ...
}
```