### PR TITLE
docs: Add default values for all optional environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,21 @@ To use the `signOut` method, you'll need to set a default Logout URI in your Wor
 
 Certain environment variables are optional and can be used to debug or configure cookie settings.
 
-```sh
-WORKOS_COOKIE_MAX_AGE='600' # maximum age of the cookie in seconds. Defaults to 400 days, the maximum allowed in Chrome
-WORKOS_COOKIE_DOMAIN='example.com'
-WORKOS_COOKIE_NAME='authkit-cookie'
-WORKOS_API_HOSTNAME='api.workos.com' # base WorkOS API URL
-WORKOS_API_HTTPS=true # whether to use HTTPS in API calls
-WORKOS_API_PORT=3000 # port to use for API calls
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| `WORKOS_COOKIE_MAX_AGE` | `34560000` (400 days) | Maximum age of the cookie in seconds |
+| `WORKOS_COOKIE_DOMAIN` | None | Domain for the cookie. When empty, the cookie is only valid for the current domain |
+| `WORKOS_COOKIE_NAME` | `'wos-session'` | Name of the session cookie |
+| `WORKOS_API_HOSTNAME` | `'api.workos.com'` | Base WorkOS API URL |
+| `WORKOS_API_HTTPS` | `true` | Whether to use HTTPS in API calls |
+| `WORKOS_API_PORT` | None | Port to use for API calls. When not set, uses standard ports (443 for HTTPS, 80 for HTTP) |
+| `WORKOS_COOKIE_SAMESITE` | `'lax'` | SameSite attribute for cookies. Options: `'lax'`, `'strict'`, or `'none'` |
 
-# Only change this if you specifically need cross-origin cookie support.
-WORKOS_COOKIE_SAMESITE='lax' # SameSite attribute for cookies: 'lax' (default), 'strict', or 'none'.
+Example usage:
+```sh
+WORKOS_COOKIE_MAX_AGE='600'
+WORKOS_COOKIE_DOMAIN='example.com'
+WORKOS_COOKIE_NAME='my-auth-cookie'
 ```
 
 > [!WARNING]


### PR DESCRIPTION
## Summary
- Updated README to include default values for all optional environment variables
- Converted the optional configuration section to use a markdown table for better clarity
- Fixes #264 

## Changes
The optional environment variables section now clearly shows:
- `WORKOS_COOKIE_MAX_AGE`: Defaults to `34560000` (400 days)
- `WORKOS_COOKIE_DOMAIN`: Defaults to None (host-only cookie)
- `WORKOS_COOKIE_NAME`: Defaults to `'wos-session'`
- `WORKOS_API_HOSTNAME`: Defaults to `'api.workos.com'`
- `WORKOS_API_HTTPS`: Defaults to `true`
- `WORKOS_API_PORT`: Defaults to None (uses standard ports)
- `WORKOS_COOKIE_SAMESITE`: Defaults to `'lax'`

The table format makes it much easier to scan and understand the default behavior when these variables are not set.

Fixes #264