### PR TITLE
Fix: Prevent infinite token refresh loop for long-lived sessions

### DIFF
--- a/src/components/useAccessToken.ts
+++ b/src/components/useAccessToken.ts
@@ -4,6 +4,7 @@ import { useAuth } from './authkit-provider.js';
 
 const TOKEN_EXPIRY_BUFFER_SECONDS = 60;
 const MIN_REFRESH_DELAY_SECONDS = 15; // minimum delay before refreshing token
+const MAX_REFRESH_DELAY_SECONDS = 24 * 60 * 60; // 24 hours
 const RETRY_DELAY_SECONDS = 300; // 5 minutes
 
 interface TokenState {
@@ -35,7 +36,11 @@ function tokenReducer(state: TokenState, action: TokenAction): TokenState {
 }
 
 function getRefreshDelay(timeUntilExpiry: number) {
-  return Math.max((timeUntilExpiry - TOKEN_EXPIRY_BUFFER_SECONDS) * 1000, MIN_REFRESH_DELAY_SECONDS * 1000);
+  const idealDelay = (timeUntilExpiry - TOKEN_EXPIRY_BUFFER_SECONDS) * 1000;
+  return Math.min(
+    Math.max(idealDelay, MIN_REFRESH_DELAY_SECONDS * 1000),
+    MAX_REFRESH_DELAY_SECONDS * 1000
+  );
 }
 
 function parseToken(token: string | undefined) {


### PR DESCRIPTION
## Summary
- Fixes an infinite loop in `useAccessToken` hook when WorkOS session length is set to 25+ days
- Adds a maximum refresh delay of 24 hours to prevent JavaScript setTimeout overflow

## Problem
When the WorkOS dashboard is configured with session lengths of 25 days or more, the `useAccessToken` hook enters an infinite refresh loop. This happens because:

1. The calculated refresh delay exceeds JavaScript's maximum setTimeout value (2^31-1 milliseconds ≈ 24.8 days)
2. When setTimeout receives a value larger than this maximum, it wraps around to a negative number
3. This causes the timer to fire immediately, creating an infinite loop of token refreshes

## Solution
Added a `MAX_REFRESH_DELAY_SECONDS` constant set to 24 hours and updated the `getRefreshDelay` function to cap the refresh delay:

```typescript
const MAX_REFRESH_DELAY_SECONDS = 24 * 60 * 60; // 24 hours

function getRefreshDelay(timeUntilExpiry: number) {
  const idealDelay = (timeUntilExpiry - TOKEN_EXPIRY_BUFFER_SECONDS) * 1000;
  return Math.min(
    Math.max(idealDelay, MIN_REFRESH_DELAY_SECONDS * 1000),
    MAX_REFRESH_DELAY_SECONDS * 1000
  );
}
```

This ensures:
- No setTimeout overflow issues regardless of session length
- Tokens are refreshed at least once every 24 hours for long-lived sessions
- Existing behavior is preserved for sessions shorter than 24 hours

## Test plan
- [x] Verify existing tests pass
- [ ] Test with WorkOS session length < 24 hours (should refresh 60 seconds before expiry)
- [ ] Test with WorkOS session length = 25 days (should refresh every 24 hours)
- [ ] Test with WorkOS session length = 30 days (should refresh every 24 hours)
- [ ] Monitor console logs to ensure no rapid refresh loops