### PR TITLE
docs: Update README to include explicitly passing baseURL in containerized environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ export const GET = handleAuth({
 });
 ```
 
+When running in environments like Docker, set the `baseURL` explicitly to ensure the redirects point to the correct location. 
+
+```ts
+export const GET = handleAuth({
+  baseURL: 'http://localhost:3000',
+});
+```
+
 `handleAuth` can be used with the following options.
 
 | Option           | Default     | Description                                                                                                                                                                                           |


### PR DESCRIPTION
Customers have shown confusion about having to explicitly pass the baseURL in containerized environments:
- [GH issue](https://github.com/workos/authkit-nextjs/issues/37)

This update adds that `baseURL` is required for containerized environments and provides an example. 