### PR TITLE
Fix intermittent Turbopack build errors by removing .js extensions from Next.js imports

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,8 +1,8 @@
 'use server';
 
-import { revalidatePath, revalidateTag } from 'next/cache.js';
-import { cookies, headers } from 'next/headers.js';
-import { redirect } from 'next/navigation.js';
+import { revalidatePath, revalidateTag } from 'next/cache';
+import { cookies, headers } from 'next/headers';
+import { redirect } from 'next/navigation';
 import { WORKOS_COOKIE_NAME } from './env-variables.js';
 import { getCookieOptions } from './cookie.js';
 import { getAuthorizationUrl } from './get-authorization-url.js';


### PR DESCRIPTION
## Summary

Removes explicit `.js` file extensions from Next.js core module imports in `src/auth.ts` to resolve intermittent build failures when using Turbopack.

## Problem

Users reported intermittent "Could not parse module" errors when using `next dev --turbo` with authkit-nextjs v2.4.0 and later. The issue was non-deterministic and primarily affected Turbopack builds, though some users also experienced related issues in standard webpack builds.

The error manifested as:
- `Error: Could not parse module` in Turbopack
- Build failures when importing `@workos-inc/authkit-nextjs` in server routes
- Issues with client component compilation in some cases

## Root Cause

The issue was caused by explicit `.js` extensions in imports for Next.js core modules:
```typescript
import { revalidatePath, revalidateTag } from 'next/cache.js';
import { cookies, headers } from 'next/headers.js';
import { redirect } from 'next/navigation.js';
```

Turbopack's module resolution behaves differently than webpack when handling these explicit extensions, leading to parsing failures in certain build configurations.

## Solution

Removed the `.js` extensions from Next.js core module imports:
```typescript
import { revalidatePath, revalidateTag } from 'next/cache';
import { cookies, headers } from 'next/headers';
import { redirect } from 'next/navigation';
```

This aligns with Next.js documentation and best practices, which recommend importing these modules without explicit extensions. The TypeScript compiler and Next.js bundlers handle the resolution automatically.

## Impact

- Resolves intermittent Turbopack build failures
- Maintains compatibility with standard webpack builds  
- Follows Next.js import conventions
- No breaking changes to the public API

Fixes #269