### PR TITLE
Add afterAuth to `authkitMiddleware` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,20 @@ export default async function middleware(request: NextRequest) {
 export const config = { matcher: ['/', '/account/:path*'] };
 ```
 
+### After auth functions
+
+If you do not want to run your own middleware with `authkit` and instead want to run a function after a user is authenticated, you can use the `afterAuth` option on `authkitMiddleware`.
+
+```ts
+
+export default authkitMiddleware({
+  // Run after the user is authenticated
+  afterAuth: async (userInfo, req) => {
+    ErrorClient.setUser(userInfo);
+  },
+});
+```
+
 ### Signing out
 
 Use the `signOut` method to sign out the current logged in user and redirect to your app's default Logout URI. The Logout URI is set in your WorkOS dashboard settings under "Redirect".

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -71,11 +71,14 @@ export interface AuthkitMiddlewareAuth {
   unauthenticatedPaths: string[];
 }
 
+export type AfterAuthFunction = (userInfo: UserInfo, req: NextRequest) => void | Promise<void>;
+
 export interface AuthkitMiddlewareOptions {
   debug?: boolean;
   middlewareAuth?: AuthkitMiddlewareAuth;
   redirectUri?: string;
   signUpPaths?: string[];
+  afterAuth?: AfterAuthFunction;
 }
 
 export interface AuthkitOptions {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,9 +8,10 @@ export function authkitMiddleware({
   middlewareAuth = { enabled: false, unauthenticatedPaths: [] },
   redirectUri = WORKOS_REDIRECT_URI,
   signUpPaths = [],
+  afterAuth,
 }: AuthkitMiddlewareOptions = {}): NextMiddleware {
   return function (request) {
-    return updateSessionMiddleware(request, debug, middlewareAuth, redirectUri, signUpPaths);
+    return updateSessionMiddleware({ request, debug, middlewareAuth, redirectUri, signUpPaths, afterAuth });
   };
 }
 


### PR DESCRIPTION
Add afterAuth to `authkitMiddleware` so folks don't have to compose the middleware themselves but can run code after auth, before .next