### PR TITLE
Fix: Show loading state during initial token fetch to prevent flash

### DIFF
--- a/__tests__/useAccessToken.spec.tsx
+++ b/__tests__/useAccessToken.spec.tsx
@@ -57,15 +57,15 @@ describe('useAccessToken', () => {
     );
   };
 
-  it('should fetch an access token on mount without showing loading state', async () => {
+  it('should fetch an access token on mount and show loading state initially', async () => {
     const mockToken =
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwic2lkIjoic2Vzc2lvbl8xMjMiLCJleHAiOjk5OTk5OTk5OTl9.mock-signature';
     (getAccessTokenAction as jest.Mock).mockResolvedValueOnce(mockToken);
 
     const { getByTestId } = render(<TestComponent />);
 
-    // Loading should remain false for background fetches
-    expect(getByTestId('loading')).toHaveTextContent('false');
+    // Loading should be true during initial fetch
+    expect(getByTestId('loading')).toHaveTextContent('true');
 
     await waitFor(() => {
       expect(getAccessTokenAction).toHaveBeenCalledTimes(1);
@@ -77,7 +77,7 @@ describe('useAccessToken', () => {
     });
   });
 
-  it('should handle token refresh when an expiring token is received without showing loading', async () => {
+  it('should handle token refresh when an expiring token is received', async () => {
     // Create a token that's about to expire (exp is very close to current time)
     const currentTimeInSeconds = Math.floor(Date.now() / 1000);
     // Use 25 seconds to ensure it's within the 30-second buffer for short-lived tokens
@@ -97,8 +97,8 @@ describe('useAccessToken', () => {
 
     const { getByTestId } = render(<TestComponent />);
 
-    // Loading should remain false throughout
-    expect(getByTestId('loading')).toHaveTextContent('false');
+    // Loading should be true initially during token fetch
+    expect(getByTestId('loading')).toHaveTextContent('true');
 
     await waitFor(() => {
       expect(getByTestId('loading')).toHaveTextContent('false');
@@ -155,14 +155,14 @@ describe('useAccessToken', () => {
     });
   });
 
-  it('should handle errors during token fetch without showing loading', async () => {
+  it('should handle errors during token fetch', async () => {
     const error = new Error('Failed to fetch token');
     (getAccessTokenAction as jest.Mock).mockRejectedValueOnce(error);
 
     const { getByTestId } = render(<TestComponent />);
 
-    // Loading should remain false even when there's an error
-    expect(getByTestId('loading')).toHaveTextContent('false');
+    // Loading should be true initially
+    expect(getByTestId('loading')).toHaveTextContent('true');
 
     await waitFor(() => {
       expect(getByTestId('loading')).toHaveTextContent('false');
@@ -381,8 +381,8 @@ describe('useAccessToken', () => {
 
     const { getByTestId } = render(<TestComponent />);
 
-    // Loading should remain false for background operations
-    expect(getByTestId('loading')).toHaveTextContent('false');
+    // Loading should be true initially during fetch
+    expect(getByTestId('loading')).toHaveTextContent('true');
 
     await waitFor(() => {
       expect(fetchCalls).toBe(1);

--- a/src/components/useAccessToken.ts
+++ b/src/components/useAccessToken.ts
@@ -69,10 +69,10 @@ export function useAccessToken(): UseAccessTokenReturn {
     /* istanbul ignore next */
     tokenStore
       .getAccessTokenSilently()
-      .finally(() => setIsInitialTokenLoading(false))
       .catch(() => {
         // Error is handled in the store
-      });
+      })
+      .finally(() => setIsInitialTokenLoading(false));
   }, [userId, sessionId]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
Fixes a race condition that causes a flash of unauthenticated state during initial token fetch.

## Problem
`useAccessToken` was reporting `loading: false` while fetching the initial token, causing downstream consumers to briefly show unauthenticated state before the token arrived.

This issue necessitated workarounds like checking `!accessToken` in loading calculations (see workos/template-convex-nextjs-authkit#5), which breaks for logged-out users.

## Solution
- Add `isInitialTokenLoading` state to track initial token fetch
- Report `loading: true` until the initial fetch completes
- Logged-out users continue to see `loading: false` as expected

## Testing
Updated tests to verify the loading state is shown during initial token fetch.