### PR TITLE
reduce test coverage thresholds to 80%

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -56,10 +56,10 @@ const config: Config = {
 
   coverageThreshold: {
     global: {
-      branches: 100,
-      functions: 100,
-      lines: 100,
-      statements: 100,
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
     },
   },
 };


### PR DESCRIPTION
This pull request lowers the global code coverage thresholds in the Jest configuration from 100% to 80%. This change makes it easier for tests to pass by allowing for less than full coverage.

Testing configuration update:

* Reduced global coverage thresholds for branches, functions, lines, and statements from 100% to 80% in `jest.config.ts`.