### PR TITLE
Allow onSuccess callback to update session

### DIFF
--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -61,6 +61,8 @@ export function handleAuth(options: HandleAuthOptions = {}) {
 
         if (!accessToken || !refreshToken) throw new Error('response is missing tokens');
 
+        await saveSession({ accessToken, refreshToken, user, impersonator }, request);
+
         if (onSuccess) {
           await onSuccess({
             accessToken,
@@ -72,8 +74,6 @@ export function handleAuth(options: HandleAuthOptions = {}) {
             organizationId,
           });
         }
-
-        await saveSession({ accessToken, refreshToken, user, impersonator }, request);
 
         return response;
       } catch (error) {

--- a/src/components/useAccessToken.ts
+++ b/src/components/useAccessToken.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { useAuth } from './authkit-provider.js';
 import { tokenStore } from './tokenStore.js';


### PR DESCRIPTION
Today, it's not possible to refresh a token and save it to the session in the `onSuccess` callback in your callback route. That's because `handleAuth` calls `saveSession` with the original token after it calls your `onSuccess` callback.

This PR allows changes you save to the session in your `onSuccess` callback to persist after redirecting.