### PR TITLE
Fix docs around eagerAuth usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ export default async function HomePage() {
 For client components, use the `useAuth` hook to get the current user session.
 
 ```jsx
-'use client'
+'use client';
 // Note the updated import path
 import { useAuth } from '@workos-inc/authkit-nextjs/components';
 
@@ -461,10 +461,10 @@ Then access the token synchronously in your client components:
 ```tsx
 'use client';
 
-import { useAuth } from '@workos-inc/authkit-nextjs';
+import { useAccessToken } from '@workos-inc/authkit-nextjs/components';
 
 function MyComponent() {
-  const { getAccessToken } = useAuth();
+  const { getAccessToken } = useAccessToken();
 
   // Token is available immediately on initial page load
   const token = getAccessToken();


### PR DESCRIPTION
- correct import
- correct hook to be `useAccessToken` (not `useAuth`)

This pull request updates the usage examples in the `README.md` to reflect changes in the recommended import paths and hooks for authentication in client components. The most important changes are grouped below:

**Authentication Hook Updates:**

* Changed the import path for the `useAuth` hook to `@workos-inc/authkit-nextjs/components` in client component examples to match the latest package structure.
* Updated the synchronous access token example to use the new `useAccessToken` hook from `@workos-inc/authkit-nextjs/components`, replacing the previous usage of `useAuth`.