### PR TITLE
v2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-nextjs",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^7.67.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -2,7 +2,7 @@ import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 import { lazy } from './utils.js';
 
-export const VERSION = '2.9.0';
+export const VERSION = '2.10.0';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
This pull request updates the package version for `@workos-inc/authkit-nextjs` from 2.9.0 to 2.10.0. The version constant in the codebase has also been updated to reflect this new release.

## Changes

- #314

Version update:

* Updated the `version` field in `package.json` to 2.10.0.
* Changed the `VERSION` constant in `src/workos.ts` to 2.10.0.