### PR TITLE
v2.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-nextjs",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^7.72.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -2,7 +2,7 @@ import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 import { lazy } from './utils.js';
 
-export const VERSION = '2.11.0';
+export const VERSION = '2.11.1';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
This pull request includes a version bump for the `@workos-inc/authkit-nextjs` package from `2.11.0` to `2.11.1`. The only changes are updates to the version number in both the `package.json` file and the `VERSION` export in `src/workos.ts`.

- Bumped package version to `2.11.1` in `package.json`
- Updated `VERSION` export to `2.11.1` in `src/workos.ts`