### PR TITLE
fix: clear session cookies when onSuccess fails

### DIFF
--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -99,8 +99,6 @@ export function handleAuth(options: HandleAuthOptions = {}) {
 
         if (!accessToken || !refreshToken) throw new Error('response is missing tokens');
 
-        await saveSession({ accessToken, refreshToken, user, impersonator }, request);
-
         if (onSuccess) {
           await onSuccess({
             accessToken,
@@ -113,6 +111,8 @@ export function handleAuth(options: HandleAuthOptions = {}) {
             state: customState,
           });
         }
+
+        await saveSession({ accessToken, refreshToken, user, impersonator }, request);
 
         return response;
       } catch (error) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -625,4 +625,10 @@ export async function saveSession(
   nextCookies.set(cookieName, encryptedSession, getCookieOptions(url));
 }
 
+export async function deleteSession() {
+  const nextCookies = await cookies();
+  const cookieName = WORKOS_COOKIE_NAME || 'wos-session';
+  nextCookies.delete(cookieName);
+}
+
 export { encryptSession, refreshSession, updateSession, updateSessionMiddleware, withAuth };


### PR DESCRIPTION
Fixes #334

**Overview**
This pull request fixes an issue where authentication cookies were being set even when the onSuccess callback inside handleAuth threw an error. This resulted in inconsistent auth state: the callback route returned an error, but the user was still marked as authenticated.

**What’s changed**

- Updated the authentication flow to ensure cookies are only set after the onSuccess callback completes successfully.

- If onSuccess throws an error, cookie-setting is skipped and the error is correctly propagated to the callback route.

**Reason for the change**
The previous behavior caused misleading authentication states and made debugging difficult. Authentication should not be considered successful if onSuccess fails.

**How to test**

1. Add an onSuccess function in app/callback/route.ts.
2. Throw an error inside it.
3. Confirm that:  
  - The callback route shows the error.  
  - No cookies are set.

**Impact**
Ensures correctness and consistency in the authentication flow and prevents unintended authenticated sessions.
