### PR TITLE
Switch runner to ubuntu-latest for socket action

### DIFF
--- a/.github/workflows/socket-tier1-analysis.yml
+++ b/.github/workflows/socket-tier1-analysis.yml
@@ -9,7 +9,7 @@ on:
       tags:
         description: 'Manually run vulnerability analysis'
       distinct_id:
-        description: "Required by the return-dispatch action"
+        description: 'Required by the return-dispatch action'
         required: true
 
 concurrency:
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   socket-vulnerability-analysis:
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
This pull request makes a couple of small updates to the GitHub Actions workflow configuration for `socket-tier1-analysis`. The main changes are updating the runner environment and making a minor formatting adjustment.

- Workflow runner update:
  * Changed the workflow runner from `depot-ubuntu-22.04-4` to `ubuntu-latest` to use the default GitHub-hosted runner.

- Formatting and consistency:
  * Standardized the quotes in the `distinct_id` description for consistency with other fields.