### PR TITLE
fix: handle full URLs in returnPathname to prevent malformed redirects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-nextjs",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^7.72.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "module",

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -2,7 +2,7 @@ import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 import { lazy } from './utils.js';
 
-export const VERSION = '2.12.0';
+export const VERSION = '2.12.1';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
## Summary
- Fixes handling of full URLs in `returnPathname` by extracting only the pathname and search params
- Simplifies search params assignment using direct `url.search` assignment instead of iterating
- Bumps Next.js dev dependencies to patched versions

## Included PRs
- #341 - fix: bump Next.js dev dependency to patched version
- #339 - switch runner to ubuntu-latest for socket action
- #338 - Socket workflow integration