### PR TITLE
feat: add TokenRefreshError with userId and sessionId for debugging

### DIFF
--- a/src/errors.spec.ts
+++ b/src/errors.spec.ts
@@ -1,0 +1,108 @@
+import { AuthKitError, TokenRefreshError, getSessionErrorContext } from './errors.js';
+import type { Session } from './interfaces.js';
+import type { User } from '@workos-inc/node';
+
+describe('AuthKitError', () => {
+  it('creates error with message', () => {
+    const error = new AuthKitError('Test error');
+
+    expect(error.message).toBe('Test error');
+    expect(error.name).toBe('AuthKitError');
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('creates error with cause and data', () => {
+    const originalError = new Error('Original error');
+    const data = { userId: '123' };
+    const error = new AuthKitError('Test error', originalError, data);
+
+    expect(error.cause).toBe(originalError);
+    expect(error.data).toEqual(data);
+  });
+});
+
+describe('TokenRefreshError', () => {
+  it('creates error with correct name and inheritance', () => {
+    const error = new TokenRefreshError('Refresh failed');
+
+    expect(error.name).toBe('TokenRefreshError');
+    expect(error.message).toBe('Refresh failed');
+    expect(error).toBeInstanceOf(AuthKitError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('creates error with cause and context', () => {
+    const originalError = new Error('Network error');
+    const error = new TokenRefreshError('Refresh failed', originalError, {
+      userId: 'user_123',
+      sessionId: 'session_456',
+    });
+
+    expect(error.cause).toBe(originalError);
+    expect(error.userId).toBe('user_123');
+    expect(error.sessionId).toBe('session_456');
+  });
+
+  it('has undefined properties when no context provided', () => {
+    const error = new TokenRefreshError('Refresh failed');
+
+    expect(error.userId).toBeUndefined();
+    expect(error.sessionId).toBeUndefined();
+  });
+});
+
+describe('getSessionErrorContext', () => {
+  function createTestJwt(payload: Record<string, unknown>): string {
+    const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+    const payloadStr = btoa(JSON.stringify(payload));
+    return `${header}.${payloadStr}.test-signature`;
+  }
+
+  it('returns empty object for missing session', () => {
+    expect(getSessionErrorContext(null)).toEqual({});
+    expect(getSessionErrorContext(undefined)).toEqual({});
+  });
+
+  it('extracts userId and sessionId from access token', () => {
+    const session: Session = {
+      accessToken: createTestJwt({ sub: 'user_456', sid: 'session_123' }),
+      refreshToken: 'refresh_token',
+      user: {
+        id: 'user_456',
+        email: 'test@example.com',
+        emailVerified: true,
+        profilePictureUrl: null,
+        firstName: null,
+        lastName: null,
+        createdAt: '2024-01-01',
+        updatedAt: '2024-01-01',
+        object: 'user',
+      } as User,
+    };
+
+    const context = getSessionErrorContext(session);
+    expect(context.userId).toBe('user_456');
+    expect(context.sessionId).toBe('session_123');
+  });
+
+  it('returns empty object for invalid JWT', () => {
+    const session: Session = {
+      accessToken: 'invalid-jwt',
+      refreshToken: 'refresh_token',
+      user: {
+        id: 'user_123',
+        email: 'test@example.com',
+        emailVerified: true,
+        profilePictureUrl: null,
+        firstName: null,
+        lastName: null,
+        createdAt: '2024-01-01',
+        updatedAt: '2024-01-01',
+        object: 'user',
+      } as User,
+    };
+
+    const context = getSessionErrorContext(session);
+    expect(context).toEqual({});
+  });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,46 @@
+import type { Session } from './interfaces.js';
+import { decodeJwt } from './jwt.js';
+
+export class AuthKitError extends Error {
+  data?: Record<string, unknown>;
+
+  constructor(message: string, cause?: unknown, data?: Record<string, unknown>) {
+    super(message);
+    this.name = 'AuthKitError';
+    this.cause = cause;
+    this.data = data;
+  }
+}
+
+export interface TokenRefreshErrorContext {
+  userId?: string;
+  sessionId?: string;
+}
+
+export class TokenRefreshError extends AuthKitError {
+  readonly userId?: string;
+  readonly sessionId?: string;
+
+  constructor(message: string, cause?: unknown, context?: TokenRefreshErrorContext) {
+    super(message, cause);
+    this.name = 'TokenRefreshError';
+    this.userId = context?.userId;
+    this.sessionId = context?.sessionId;
+  }
+}
+
+export function getSessionErrorContext(session?: Session | null): TokenRefreshErrorContext {
+  if (!session?.accessToken) {
+    return {};
+  }
+
+  try {
+    const { payload } = decodeJwt(session.accessToken);
+    return {
+      userId: payload.sub,
+      sessionId: payload.sid,
+    };
+  } catch {
+    return {};
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { getSignInUrl, getSignUpUrl, signOut, switchToOrganization } from './auth.js';
 import { handleAuth } from './authkit-callback-route.js';
+import { AuthKitError, TokenRefreshError } from './errors.js';
 import { authkit, authkitMiddleware } from './middleware.js';
 import { getTokenClaims, refreshSession, saveSession, withAuth } from './session.js';
 import { validateApiKey } from './validate-api-key.js';
@@ -8,6 +9,8 @@ import { getWorkOS } from './workos.js';
 export * from './interfaces.js';
 
 export {
+  AuthKitError,
+  TokenRefreshError,
   authkit,
   authkitMiddleware,
   getSignInUrl,

--- a/src/session.ts
+++ b/src/session.ts
@@ -7,6 +7,7 @@ import { redirect } from 'next/navigation';
 import { NextRequest, NextResponse } from 'next/server';
 import { getCookieOptions, getJwtCookie } from './cookie.js';
 import { WORKOS_CLIENT_ID, WORKOS_COOKIE_NAME, WORKOS_COOKIE_PASSWORD, WORKOS_REDIRECT_URI } from './env-variables.js';
+import { TokenRefreshError, getSessionErrorContext } from './errors.js';
 import { getAuthorizationUrl } from './get-authorization-url.js';
 import {
   AccessToken,
@@ -406,9 +407,11 @@ async function refreshSession({
       organizationId: nextOrganizationId ?? organizationIdFromAccessToken,
     });
   } catch (error) {
-    throw new Error(`Failed to refresh session: ${error instanceof Error ? error.message : String(error)}`, {
-      cause: error,
-    });
+    throw new TokenRefreshError(
+      `Failed to refresh session: ${error instanceof Error ? error.message : String(error)}`,
+      error,
+      getSessionErrorContext(session),
+    );
   }
 
   const headersList = await headers();


### PR DESCRIPTION
## Problem

When token refresh fails, the error doesn't include enough context to debug which user/session was affected. This makes it harder to correlate errors with specific users in logs or the WorkOS dashboard.

## Solution

Add `TokenRefreshError` (matching the pattern in `authkit-session`) that includes `userId` and `sessionId` on the error object. These are extracted from the session before throwing.

## Example Output

```
⨯ Error [TokenRefreshError]: Failed to refresh session: Error: invalid_grant
Error Description: Session has already ended.
    at async testRefresh (src/app/test-error/actions.ts:7:5)
   5 | export async function testRefresh() {
   6 |   try {
>  7 |     await refreshSession();
     |     ^
   8 |     return { success: true };
   9 |   } catch (error) {
  10 |     if (error instanceof TokenRefreshError) { {
  data: undefined,
  userId: 'user_01ABC123...',
  sessionId: 'session_01XYZ789...',
  digest: '1995551028',
  [cause]: OauthException: Error: invalid_grant
  Error Description: Session has already ended.
      at Generator.throw (<anonymous>) {
    status: 400,
    requestID: '',
    error: 'invalid_grant',
    errorDescription: 'Session has already ended.',
    rawData: {
      error: 'invalid_grant',
      error_description: 'Session has already ended.'
    }
  }
}
```

Consumers can catch and inspect these properties:

```typescript
import { TokenRefreshError } from '@workos-inc/authkit-nextjs';

try {
  await refreshSession();
} catch (error) {
  if (error instanceof TokenRefreshError) {
    console.error('Refresh failed for user:', error.userId, 'session:', error.sessionId);
  }
}
```