### PR TITLE
fix: avoid calling headers() in middleware context

### DIFF
--- a/src/get-authorization-url.ts
+++ b/src/get-authorization-url.ts
@@ -4,16 +4,12 @@ import { GetAuthURLOptions } from './interfaces.js';
 import { headers } from 'next/headers';
 
 async function getAuthorizationUrl(options: GetAuthURLOptions = {}) {
-  const headersList = await headers();
-  const {
-    returnPathname,
-    screenHint,
-    organizationId,
-    redirectUri = headersList.get('x-redirect-uri'),
-    loginHint,
-    prompt,
-    state: customState,
-  } = options;
+  const { returnPathname, screenHint, organizationId, loginHint, prompt, state: customState } = options;
+  let redirectUri = options.redirectUri;
+  if (!redirectUri) {
+    const headersList = await headers();
+    redirectUri = headersList.get('x-redirect-uri') ?? undefined;
+  }
 
   const internalState = returnPathname
     ? btoa(JSON.stringify({ returnPathname })).replace(/\+/g, '-').replace(/\//g, '_')


### PR DESCRIPTION
## Summary

- Makes the `headers()` call conditional in `getAuthorizationUrl()` - only called when `redirectUri` isn't already provided
- Fixes "headers was called outside request scope" error when running Next.js standalone output with Bun

The `headers()` function from `next/headers` is designed for Server Components and Route Handlers, not middleware. When `getAuthorizationUrl()` is called from middleware context (via `updateSession`), `redirectUri` is already passed in, so we can skip the `headers()` call entirely.

Fixes #288