### PR TITLE
fix(test): restore document.querySelector mock in afterEach

### DIFF
--- a/src/components/min-max-button.spec.tsx
+++ b/src/components/min-max-button.spec.tsx
@@ -14,6 +14,7 @@ describe('MinMaxButton', () => {
   afterEach(() => {
     // Clean up after each test
     document.body.innerHTML = '';
+    jest.restoreAllMocks();
   });
 
   it('sets minimized value when clicked', () => {


### PR DESCRIPTION
In `min-max-button.spec.tsx`, `document.querySelector` was mocked but not restored. Fixed by adding `jest.restoreAllMocks()` inside the `afterEach()` hook.

