### PR TITLE
v2.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "packageManager": "pnpm@10.28.0",
   "sideEffects": false,

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -2,7 +2,7 @@ import { WorkOS } from '@workos-inc/node';
 import { WORKOS_API_HOSTNAME, WORKOS_API_KEY, WORKOS_API_HTTPS, WORKOS_API_PORT } from './env-variables.js';
 import { lazy } from './utils.js';
 
-export const VERSION = '2.13.0';
+export const VERSION = '2.14.0';
 
 const options = {
   apiHostname: WORKOS_API_HOSTNAME,


### PR DESCRIPTION
## Summary

This release upgrades the WorkOS Node SDK dependency to v8, migrates the test framework from Jest to Vitest, switches the package manager from npm to pnpm, and adds documentation improvements.

### Dependencies
- **Upgrade `@workos-inc/node` from v7 to v8** (#368) — Bumps the WorkOS Node SDK to the latest major version. No source code changes were required, indicating full backwards compatibility for this library's usage.

### Documentation
- **Catch-all middleware matcher warning** (#355) — Adds a warning to the README about catch-all matcher patterns intercepting static assets (CSS, images, fonts), which can break styles with Tailwind CSS v4. Includes a recommended matcher pattern that excludes Next.js static paths.

### Internal / Tooling
- **Migrate from Jest to Vitest** (#367) — Replaces Jest with Vitest across all 19 test files (294 tests). Uses `environmentMatchGlobs` to run `.spec.tsx` in jsdom and `.spec.ts` in Node. Adds `@vitest/coverage-v8` for coverage support.
- **Switch from npm to pnpm** (#360) — Adopts pnpm as the package manager with `packageManager` field in package.json. Updates CI workflows, scripts, and README install instructions accordingly.
- **Add example app as pnpm workspace package** (#370) — Moves the `next-authkit-example` app into `example/` as a workspace member, replacing the fragile `relative-deps` approach with `workspace:*` linking.

## Semver
**MINOR** — The `@workos-inc/node` v8 dependency bump is the only user-facing change. No breaking changes to the public API of this library. All other changes are internal tooling and documentation.