### PR TITLE
fix: allow dashboard impersonation to bypass PKCE/CSRF verification

### DIFF
--- a/src/authkit-callback-route.spec.ts
+++ b/src/authkit-callback-route.spec.ts
@@ -472,14 +472,29 @@ describe('authkit-callback-route', () => {
         expect(response.status).not.toBe(500);
       });
 
-      it('should return 500 when neither state nor cookie exist', async () => {
+      it('should still reject when state is present but cookie is missing', async () => {
         vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue(mockAuthResponse);
 
         request.nextUrl.searchParams.set('code', 'test-code');
+        request.nextUrl.searchParams.set('state', 'some-state');
 
         const handler = handleAuth();
         const response = await handler(request);
 
+        expect(workos.userManagement.authenticateWithCode).not.toHaveBeenCalled();
+        expect(response.status).toBe(500);
+      });
+
+      it('should not treat empty state string as impersonation', async () => {
+        vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue(mockAuthResponse);
+
+        request.nextUrl.searchParams.set('code', 'test-code');
+        request.nextUrl.searchParams.set('state', '');
+
+        const handler = handleAuth();
+        const response = await handler(request);
+
+        // Empty state is not null — should enter normal PKCE flow and fail (no matching cookie)
         expect(workos.userManagement.authenticateWithCode).not.toHaveBeenCalled();
         expect(response.status).toBe(500);
       });
@@ -594,6 +609,114 @@ describe('authkit-callback-route', () => {
         const pkceDeletionCookie = setCookieHeaders.find((c: string) => c.startsWith('wos-auth-verifier='));
         expect(pkceDeletionCookie).toBeDefined();
         expect(pkceDeletionCookie).toContain('Max-Age=0');
+      });
+    });
+
+    describe('dashboard impersonation', () => {
+      const mockImpersonationResponse = {
+        ...mockAuthResponse,
+        impersonator: {
+          email: 'admin@example.com',
+          reason: 'Debugging user issue',
+        },
+      };
+
+      it('should succeed when code is present but state and cookie are both absent', async () => {
+        vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue(mockImpersonationResponse);
+
+        request.nextUrl.searchParams.set('code', 'impersonation-code');
+
+        const handler = handleAuth();
+        const response = await handler(request);
+
+        expect(workos.userManagement.authenticateWithCode).toHaveBeenCalledWith({
+          clientId: process.env.WORKOS_CLIENT_ID,
+          code: 'impersonation-code',
+          codeVerifier: undefined,
+        });
+        expect(response.status).toBe(307);
+      });
+
+      it('should redirect to the default returnPathname', async () => {
+        vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue(mockImpersonationResponse);
+
+        request.nextUrl.searchParams.set('code', 'impersonation-code');
+
+        const handler = handleAuth({ returnPathname: '/dashboard' });
+        const response = await handler(request);
+
+        expect(response.headers.get('Location')).toContain('/dashboard');
+      });
+
+      it('should save session with impersonator data', async () => {
+        vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue(mockImpersonationResponse);
+
+        request.nextUrl.searchParams.set('code', 'impersonation-code');
+
+        const handler = handleAuth();
+        await handler(request);
+
+        const session = await getSessionFromCookie();
+        expect(session?.impersonator).toEqual({
+          email: 'admin@example.com',
+          reason: 'Debugging user issue',
+        });
+      });
+
+      it('should call onSuccess with impersonator data', async () => {
+        vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue(mockImpersonationResponse);
+
+        request.nextUrl.searchParams.set('code', 'impersonation-code');
+
+        const onSuccess = vi.fn();
+        const handler = handleAuth({ onSuccess });
+        await handler(request);
+
+        expect(onSuccess).toHaveBeenCalledWith(
+          expect.objectContaining({
+            impersonator: { email: 'admin@example.com', reason: 'Debugging user issue' },
+            state: undefined,
+          }),
+        );
+      });
+
+      it('should reject when PKCE was bypassed but response has no impersonator', async () => {
+        // Simulates an intercepted authorization code sent without state/cookie
+        vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue(mockAuthResponse);
+
+        request.nextUrl.searchParams.set('code', 'intercepted-code');
+
+        const handler = handleAuth();
+        const response = await handler(request);
+
+        expect(response.status).toBe(500);
+      });
+
+      it('should succeed even when a stale PKCE cookie exists from a prior flow', async () => {
+        vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue(mockImpersonationResponse);
+
+        // Stale cookie from a previous sign-in attempt — middleware sets this on unauthenticated requests
+        await setAuthCookie(request, { nonce: 'stale-nonce', codeVerifier: 'stale-verifier' });
+        request.nextUrl.searchParams.set('code', 'impersonation-code');
+        // No state param — this is the scenario from issue #400
+
+        const handler = handleAuth();
+        const response = await handler(request);
+
+        expect(workos.userManagement.authenticateWithCode).toHaveBeenCalledWith({
+          clientId: process.env.WORKOS_CLIENT_ID,
+          code: 'impersonation-code',
+          codeVerifier: undefined,
+        });
+        expect(response.status).toBe(307);
+      });
+
+      it('should still fail when only code is missing', async () => {
+        const handler = handleAuth();
+        const response = await handler(request);
+
+        expect(workos.userManagement.authenticateWithCode).not.toHaveBeenCalled();
+        expect(response.status).toBe(500);
       });
     });
   });

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -41,26 +41,37 @@ export function handleAuth(options: HandleAuthOptions = {}) {
       const state = requestUrl.searchParams.get('state');
       const pkceCookie = request.cookies.get(PKCE_COOKIE_NAME)?.value;
 
-      if (!code || !state) {
-        throw new Error('Missing required auth parameter');
+      if (!code) {
+        throw new Error('Missing authorization code');
       }
 
-      // CSRF verification: both channels (cookie + URL state) must be present and match
-      if (!pkceCookie) {
-        throw new Error(
-          'Auth cookie missing — cannot verify OAuth state. Ensure Set-Cookie headers are propagated on redirects.',
-        );
-      }
+      // Dashboard impersonation: WorkOS sends only `code` (no state parameter)
+      // because the flow is initiated from the WorkOS dashboard, not from the application.
+      // A stale PKCE cookie may exist from a prior auth flow — its presence is irrelevant here.
+      // The impersonator check after code exchange guards against misuse of this path.
+      const isDashboardImpersonation = state === null;
 
-      if (state !== pkceCookie) {
-        throw new Error('OAuth state mismatch');
-      }
+      let codeVerifier: string | undefined;
+      let customState: string | undefined;
+      let returnPathnameState: string | undefined;
 
-      const {
-        codeVerifier,
-        customState,
-        returnPathname: returnPathnameState,
-      } = await getStateFromPKCECookieValue(pkceCookie);
+      if (!isDashboardImpersonation) {
+        // CSRF verification: both channels (cookie + URL state) must be present and match
+        if (!pkceCookie) {
+          throw new Error(
+            'Auth cookie missing — cannot verify OAuth state. Ensure Set-Cookie headers are propagated on redirects.',
+          );
+        }
+
+        if (state !== pkceCookie) {
+          throw new Error('OAuth state mismatch');
+        }
+
+        const stateData = await getStateFromPKCECookieValue(pkceCookie);
+        codeVerifier = stateData.codeVerifier;
+        customState = stateData.customState;
+        returnPathnameState = stateData.returnPathname;
+      }
 
       // Use the code returned to us by AuthKit and authenticate the user with WorkOS
       const { accessToken, refreshToken, user, impersonator, oauthTokens, authenticationMethod, organizationId } =
@@ -72,6 +83,12 @@ export function handleAuth(options: HandleAuthOptions = {}) {
 
       if (!accessToken || !refreshToken) {
         throw new Error('response is missing tokens');
+      }
+
+      // If we skipped PKCE/CSRF verification, the response must indicate impersonation.
+      // This prevents an intercepted authorization code from being exchanged without PKCE.
+      if (isDashboardImpersonation && !impersonator) {
+        throw new Error('PKCE/state verification was bypassed but response is not an impersonation session');
       }
 
       // If baseURL is provided, use it instead of request.nextUrl


### PR DESCRIPTION
## Summary

Fixes #400 — dashboard impersonation broken with v3 PKCE/CSRF verification.

- Dashboard impersonation is initiated by WorkOS (not the app), so the callback receives only `code` with no `state` param. The v3 PKCE hardening rejected these callbacks with `Missing required auth parameter`.
- When `state` is absent (`null`), skip PKCE/CSRF verification and exchange the code without a `codeVerifier`. After exchange, verify the response contains `impersonator` data — reject otherwise, preventing intercepted non-impersonation codes from being accepted on this path.
- Uses `state === null` (not `!state`) so empty-string state is still treated as a malformed normal flow, not impersonation.
- Normal sign-in flows with `state` still go through full PKCE/CSRF verification.

## Security considerations

- PKCE (RFC 7636) cannot be applied to server-initiated flows — the client never initiates the authorization request, so there's no opportunity to generate a code verifier.
- The `impersonator` check after code exchange is the compensating control. If the response doesn't indicate impersonation, the session is rejected.
- Attack chain for exploitation is narrow: intercept redirect to server endpoint → exchange before legitimate request (single-use code) → code must be an impersonation code (impersonator check).

## Test plan

- [x] `pnpm test` passes (345 tests)
- [x] `pnpm run build` succeeds
- [x] `pnpm run lint` passes
- [x] Impersonation succeeds with code only (no state, no cookie)
- [x] Impersonation succeeds with stale PKCE cookie present (real-world scenario)
- [x] Rejects when PKCE bypassed but response has no impersonator
- [x] Empty state string (`?state=`) is not treated as impersonation
- [x] Normal PKCE/CSRF flows still fully verified
- [x] Tested end-to-end in example app via WorkOS dashboard impersonation