### PR TITLE
fix: isolate concurrent PKCE flows to prevent cookie clobbering

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "typecheck": "tsc --project tsconfig.app.json --noEmit && tsc --project tsconfig.test.json --noEmit"
   },
   "dependencies": {
+    "@sindresorhus/fnv1a": "^3.1.0",
     "@workos-inc/node": "^8.9.0",
     "iron-session": "^8.0.4",
     "jose": "^5.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@sindresorhus/fnv1a':
+        specifier: ^3.1.0
+        version: 3.1.0
       '@workos-inc/node':
         specifier: ^8.9.0
         version: 8.9.0
@@ -1798,6 +1801,10 @@ packages:
     resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
     engines: {node: '>= 8.0.0'}
     hasBin: true
+
+  '@sindresorhus/fnv1a@3.1.0':
+    resolution: {integrity: sha512-KV321z5m/0nuAg83W1dPLy85HpHDk7Sdi4fJbwvacWsEhAh+rZUW4ZfGcXmUIvjZg4ss2bcwNlRhJ7GBEUG08w==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
@@ -4939,6 +4946,8 @@ snapshots:
     dependencies:
       fflate: 0.7.4
       string.prototype.codepointat: 0.2.1
+
+  '@sindresorhus/fnv1a@3.1.0': {}
 
   '@sindresorhus/is@7.2.0': {}
 

--- a/src/auth.spec.ts
+++ b/src/auth.spec.ts
@@ -274,6 +274,25 @@ describe('auth.ts', () => {
       expect(sessionCookie).toBeUndefined();
     });
 
+    it('should clear lingering PKCE verifier cookies (legacy and per-flow)', async () => {
+      const nextCookies = await cookies();
+      const nextHeaders = await headers();
+
+      nextHeaders.set('x-workos-middleware', 'true');
+      nextCookies.set('wos-session', 'foo');
+      nextCookies.set('wos-auth-verifier', 'legacy-state');
+      nextCookies.set('wos-auth-verifier-a1b2c3d4', 'flow-a-state');
+      nextCookies.set('wos-auth-verifier-deadbeef', 'flow-b-state');
+      nextCookies.set('unrelated-cookie', 'keep-me');
+
+      await signOut();
+
+      expect(nextCookies.get('wos-auth-verifier')).toBeUndefined();
+      expect(nextCookies.get('wos-auth-verifier-a1b2c3d4')).toBeUndefined();
+      expect(nextCookies.get('wos-auth-verifier-deadbeef')).toBeUndefined();
+      expect(nextCookies.get('unrelated-cookie')?.value).toBe('keep-me');
+    });
+
     describe('when given a `returnTo` parameter', () => {
       it('passes the `returnTo` through to the `getLogoutUrl` call', async () => {
         vi.spyOn(workos.userManagement, 'getLogoutUrl').mockReturnValue(

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,10 +5,10 @@ import { revalidatePath, revalidateTag } from 'next/cache';
 import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { WORKOS_COOKIE_NAME } from './env-variables.js';
-import { getCookieOptions } from './cookie.js';
+import { getCookieOptions, getPKCECookieOptions } from './cookie.js';
 import { getAuthorizationUrl } from './get-authorization-url.js';
 import type { AccessToken, GetAuthURLOptions, SwitchToOrganizationOptions, UserInfo } from './interfaces.js';
-import { setPKCECookie } from './pkce.js';
+import { PKCE_COOKIE_NAME, setPKCECookie } from './pkce.js';
 import { getSessionFromCookie, refreshSession, withAuth } from './session.js';
 import { getWorkOS } from './workos.js';
 
@@ -78,6 +78,24 @@ export async function signOut({ returnTo }: { returnTo?: string } = {}) {
     } catch {
       // Some environments (e.g., vinext) only accept a string cookie name
       nextCookies.delete(cookieName);
+    }
+
+    // Clear any lingering PKCE verifier cookies so orphans from abandoned
+    // flows don't accumulate toward HTTP 431 or confuse future sign-ins.
+    const pkceOptions = getPKCECookieOptions();
+    for (const { name } of nextCookies.getAll()) {
+      if (!name.startsWith(PKCE_COOKIE_NAME)) continue;
+      try {
+        nextCookies.delete({
+          name,
+          domain: pkceOptions.domain,
+          path: pkceOptions.path,
+          sameSite: pkceOptions.sameSite,
+          secure: pkceOptions.secure,
+        });
+      } catch {
+        nextCookies.delete(name);
+      }
     }
 
     if (sessionId) {

--- a/src/authkit-callback-route.spec.ts
+++ b/src/authkit-callback-route.spec.ts
@@ -635,6 +635,28 @@ describe('authkit-callback-route', () => {
         const flowBDeletion = setCookieHeaders.find((c: string) => c.startsWith(`${flowBCookieName}=`));
         expect(flowBDeletion).toBeUndefined();
       });
+
+      it('should fall back to the legacy shared PKCE cookie for v3.0.x in-flight flows', async () => {
+        vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue(mockAuthResponse);
+
+        const sealedState = await sealData(
+          { nonce: 'legacy', codeVerifier: 'legacy-verifier' },
+          { password: process.env.WORKOS_COOKIE_PASSWORD! },
+        );
+
+        // Simulate a user mid-OAuth on v3.0.x: only the legacy cookie name exists
+        request.cookies.set('wos-auth-verifier', sealedState);
+        request.nextUrl.searchParams.set('code', 'test-code');
+        request.nextUrl.searchParams.set('state', sealedState);
+
+        const handler = handleAuth();
+        const response = await handler(request);
+
+        expect(response.status).toBe(307);
+        expect(workos.userManagement.authenticateWithCode).toHaveBeenCalledWith(
+          expect.objectContaining({ codeVerifier: 'legacy-verifier' }),
+        );
+      });
     });
   });
 });

--- a/src/authkit-callback-route.spec.ts
+++ b/src/authkit-callback-route.spec.ts
@@ -1,6 +1,7 @@
 import type { Mock } from 'vitest';
 import { getWorkOS } from './workos.js';
 import { handleAuth } from './authkit-callback-route.js';
+import { getPKCECookieNameForState } from './pkce.js';
 import { getSessionFromCookie, saveSession } from './session.js';
 import { NextRequest, NextResponse } from 'next/server';
 import { sealData } from 'iron-session';
@@ -56,7 +57,7 @@ describe('authkit-callback-route', () => {
 
   async function setAuthCookie(req: NextRequest, state: State): Promise<string> {
     const sealedState = await sealData(state, { password: process.env.WORKOS_COOKIE_PASSWORD! });
-    req.cookies.set('wos-auth-verifier', sealedState);
+    req.cookies.set(getPKCECookieNameForState(sealedState), sealedState);
     return sealedState;
   }
 
@@ -548,10 +549,11 @@ describe('authkit-callback-route', () => {
       it('should return an error response when PKCE cookie is corrupted', async () => {
         vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue(mockAuthResponse);
 
-        // Set a corrupted cookie
-        request.cookies.set('wos-auth-verifier', 'not-a-valid-sealed-value');
+        // Set a corrupted cookie using the flow-specific name
+        const corruptedState = 'not-a-valid-sealed-value';
+        request.cookies.set(getPKCECookieNameForState(corruptedState), corruptedState);
         request.nextUrl.searchParams.set('code', 'test-code');
-        request.nextUrl.searchParams.set('state', 'not-a-valid-sealed-value');
+        request.nextUrl.searchParams.set('state', corruptedState);
 
         const handler = handleAuth();
         const response = await handler(request);
@@ -570,11 +572,12 @@ describe('authkit-callback-route', () => {
         const handler = handleAuth();
         const response = await handler(request);
 
-        // The response should be a redirect (success) and have a Set-Cookie header to delete the PKCE cookie
+        // The response should be a redirect (success) and have a Set-Cookie header to delete the flow-specific PKCE cookie
         expect(response.status).toBe(307);
 
+        const flowCookieName = getPKCECookieNameForState(sealedState);
         const setCookieHeaders = response.headers.getSetCookie();
-        const pkceDeletionCookie = setCookieHeaders.find((c: string) => c.startsWith('wos-auth-verifier='));
+        const pkceDeletionCookie = setCookieHeaders.find((c: string) => c.startsWith(`${flowCookieName}=`));
         expect(pkceDeletionCookie).toBeDefined();
         expect(pkceDeletionCookie).toContain('Max-Age=0');
       });
@@ -590,10 +593,47 @@ describe('authkit-callback-route', () => {
         const response = await handler(request);
 
         expect(response.status).toBe(500);
+        const flowCookieName = getPKCECookieNameForState(sealedState);
         const setCookieHeaders = response.headers.getSetCookie();
-        const pkceDeletionCookie = setCookieHeaders.find((c: string) => c.startsWith('wos-auth-verifier='));
+        const pkceDeletionCookie = setCookieHeaders.find((c: string) => c.startsWith(`${flowCookieName}=`));
         expect(pkceDeletionCookie).toBeDefined();
         expect(pkceDeletionCookie).toContain('Max-Age=0');
+      });
+
+      it('should isolate concurrent auth flows using per-flow cookie names', async () => {
+        vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue(mockAuthResponse);
+
+        // Simulate two concurrent auth flows with different sealed states
+        const sealedStateA = await sealData(
+          { nonce: 'nonce-a', codeVerifier: 'verifier-a' },
+          { password: process.env.WORKOS_COOKIE_PASSWORD! },
+        );
+        const sealedStateB = await sealData(
+          { nonce: 'nonce-b', codeVerifier: 'verifier-b' },
+          { password: process.env.WORKOS_COOKIE_PASSWORD! },
+        );
+
+        // Both cookies exist on the request (set by different middleware redirects)
+        request.cookies.set(getPKCECookieNameForState(sealedStateA), sealedStateA);
+        request.cookies.set(getPKCECookieNameForState(sealedStateB), sealedStateB);
+
+        // Callback for flow A — should find its own cookie
+        request.nextUrl.searchParams.set('code', 'code-a');
+        request.nextUrl.searchParams.set('state', sealedStateA);
+
+        const handler = handleAuth();
+        const response = await handler(request);
+
+        expect(response.status).toBe(307);
+        expect(workos.userManagement.authenticateWithCode).toHaveBeenCalledWith(
+          expect.objectContaining({ codeVerifier: 'verifier-a' }),
+        );
+
+        // Flow B's cookie should NOT have been deleted
+        const setCookieHeaders = response.headers.getSetCookie();
+        const flowBCookieName = getPKCECookieNameForState(sealedStateB);
+        const flowBDeletion = setCookieHeaders.find((c: string) => c.startsWith(`${flowBCookieName}=`));
+        expect(flowBDeletion).toBeUndefined();
       });
     });
   });

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server';
 import { getPKCECookieOptions } from './cookie.js';
 import { WORKOS_CLIENT_ID } from './env-variables.js';
 import { HandleAuthOptions } from './interfaces.js';
-import { getPKCECookieNameForState, getStateFromPKCECookieValue } from './pkce.js';
+import { PKCE_COOKIE_NAME, getPKCECookieNameForState, getStateFromPKCECookieValue } from './pkce.js';
 import { saveSession } from './session.js';
 import { errorResponseWithFallback, redirectWithFallback, setCachePreventionHeaders } from './utils.js';
 import { getWorkOS } from './workos.js';
@@ -42,8 +42,11 @@ export function handleAuth(options: HandleAuthOptions = {}) {
 
       // Derive the flow-specific cookie name from the state param so each
       // concurrent auth flow reads/deletes its own cookie, not a shared one.
+      // Fall back to the legacy shared cookie name so in-flight OAuth flows
+      // started on v3.0.x don't fail on the first callback after upgrade.
+      // Safe to remove once v3.0.x is unsupported.
       const pkceCookieName = getPKCECookieNameForState(state);
-      const pkceCookie = request.cookies.get(pkceCookieName)?.value;
+      const pkceCookie = request.cookies.get(pkceCookieName)?.value ?? request.cookies.get(PKCE_COOKIE_NAME)?.value;
 
       // CSRF verification: both channels (cookie + URL state) must be present and match
       if (!pkceCookie) {
@@ -98,10 +101,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
 
       // Always delete the PKCE cookie after handling the callback, regardless of success or error
       // to avoid stale cookies affecting future auth attempts & prevent replays
-      response.headers.append(
-        'Set-Cookie',
-        `${pkceCookieName}=; ${getPKCECookieOptions(request.url, true, true)}`,
-      );
+      response.headers.append('Set-Cookie', `${pkceCookieName}=; ${getPKCECookieOptions(request.url, true, true)}`);
 
       await saveSession({ accessToken, refreshToken, user, impersonator }, request);
 

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server';
 import { getPKCECookieOptions } from './cookie.js';
 import { WORKOS_CLIENT_ID } from './env-variables.js';
 import { HandleAuthOptions } from './interfaces.js';
-import { PKCE_COOKIE_NAME, getStateFromPKCECookieValue } from './pkce.js';
+import { getPKCECookieNameForState, getStateFromPKCECookieValue } from './pkce.js';
 import { saveSession } from './session.js';
 import { errorResponseWithFallback, redirectWithFallback, setCachePreventionHeaders } from './utils.js';
 import { getWorkOS } from './workos.js';
@@ -25,25 +25,25 @@ export function handleAuth(options: HandleAuthOptions = {}) {
   }
 
   return async function GET(request: NextRequest) {
-    // Always delete the PKCE cookie after handling the callback, regardless of success or error
-    // to avoid stale cookies affecting future auth attempts & prevent replays
-    const deleteCookie = `${PKCE_COOKIE_NAME}=; ${getPKCECookieOptions(request.url, true, true)}`;
+    // Fall back to standard URL parsing when nextUrl is not available (e.g., vinext)
+    const requestUrl = request.nextUrl ?? new URL(request.url);
 
-    // We want to catch any & all errors and respond the same way
-    // Firstly, by destroying the 1-use PKCE cookie to prevent replay attacks
-    // or stale cookies affecting future auth attempts
+    // Gather mandatory information
+    const code = requestUrl.searchParams.get('code');
+    const state = requestUrl.searchParams.get('state');
+
+    // We want to catch any & all errors and respond the same way, always
+    // destroying the 1-use PKCE cookie to prevent replay attacks or stale
+    // cookies affecting future auth attempts.
     try {
-      // Fall back to standard URL parsing when nextUrl is not available (e.g., vinext)
-      const requestUrl = request.nextUrl ?? new URL(request.url);
-
-      // Gather mandatory information
-      const code = requestUrl.searchParams.get('code');
-      const state = requestUrl.searchParams.get('state');
-      const pkceCookie = request.cookies.get(PKCE_COOKIE_NAME)?.value;
-
       if (!code || !state) {
         throw new Error('Missing required auth parameter');
       }
+
+      // Derive the flow-specific cookie name from the state param so each
+      // concurrent auth flow reads/deletes its own cookie, not a shared one.
+      const pkceCookieName = getPKCECookieNameForState(state);
+      const pkceCookie = request.cookies.get(pkceCookieName)?.value;
 
       // CSRF verification: both channels (cookie + URL state) must be present and match
       if (!pkceCookie) {
@@ -95,7 +95,13 @@ export function handleAuth(options: HandleAuthOptions = {}) {
       // This is to support Next.js 13.
       const response = redirectWithFallback(url.toString());
       preventCaching(response.headers);
-      response.headers.append('Set-Cookie', deleteCookie);
+
+      // Always delete the PKCE cookie after handling the callback, regardless of success or error
+      // to avoid stale cookies affecting future auth attempts & prevent replays
+      response.headers.append(
+        'Set-Cookie',
+        `${pkceCookieName}=; ${getPKCECookieOptions(request.url, true, true)}`,
+      );
 
       await saveSession({ accessToken, refreshToken, user, impersonator }, request);
 
@@ -116,7 +122,16 @@ export function handleAuth(options: HandleAuthOptions = {}) {
     } catch (error) {
       console.error('[AuthKit callback error]', error);
       const response = await errorResponse(request, error);
-      response.headers.append('Set-Cookie', deleteCookie);
+
+      // Always delete the PKCE cookie after handling the callback, regardless of success or error
+      // to avoid stale cookies affecting future auth attempts & prevent replays
+      if (state) {
+        response.headers.append(
+          'Set-Cookie',
+          `${getPKCECookieNameForState(state)}=; ${getPKCECookieOptions(request.url, true, true)}`,
+        );
+      }
+
       return response;
     }
   };

--- a/src/cookie.spec.ts
+++ b/src/cookie.spec.ts
@@ -278,4 +278,53 @@ describe('cookie.ts', () => {
       expect(ipCookie).not.toContain('Secure');
     });
   });
+
+  describe('getPKCECookieOptions', () => {
+    it('should use 10-minute max-age, not the session cookie max-age', async () => {
+      const { getPKCECookieOptions } = await import('./cookie');
+
+      const options = getPKCECookieOptions();
+
+      expect(options).toEqual(expect.objectContaining({ maxAge: 600 }));
+    });
+
+    it('should use 10-minute max-age in string format', async () => {
+      const { getPKCECookieOptions } = await import('./cookie');
+
+      const options = getPKCECookieOptions('http://localhost:3000', true);
+
+      expect(options).toContain('Max-Age=600');
+      expect(options).not.toContain('Max-Age=34560000');
+    });
+
+    it('should use max-age 0 when expired in object format', async () => {
+      const { getPKCECookieOptions } = await import('./cookie');
+
+      const options = getPKCECookieOptions(undefined, false, true);
+
+      expect(options).toEqual(expect.objectContaining({ maxAge: 0 }));
+    });
+
+    it('should use max-age 0 when expired in string format', async () => {
+      const { getPKCECookieOptions } = await import('./cookie');
+
+      const options = getPKCECookieOptions('http://localhost:3000', true, true);
+
+      expect(options).toContain('Max-Age=0');
+    });
+
+    it('should downgrade SameSite=Strict to Lax', async () => {
+      const envVars = await import('./env-variables');
+      Object.defineProperty(envVars, 'WORKOS_COOKIE_SAMESITE', { value: 'strict' });
+
+      const { getPKCECookieOptions } = await import('./cookie');
+
+      const objectOptions = getPKCECookieOptions();
+      expect(objectOptions).toEqual(expect.objectContaining({ sameSite: 'lax' }));
+
+      const stringOptions = getPKCECookieOptions('http://localhost:3000', true);
+      expect(stringOptions).toContain('SameSite=Lax');
+      expect(stringOptions).not.toContain('SameSite=Strict');
+    });
+  });
 });

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -92,10 +92,13 @@ export function getCookieOptions(
   };
 }
 
+const PKCE_COOKIE_MAX_AGE = 600; // 10 minutes
+
 /**
  * Cookie options for the PKCE verifier cookie.
  * 'strict' blocks the cookie on the cross-site redirect back from WorkOS; downgrade to 'lax'.
  * 'none' is more permissive and must be preserved for iframe/cross-origin embed flows.
+ * Max-age is always capped to 10 minutes — PKCE cookies are single-use and short-lived.
  */
 export function getPKCECookieOptions(): CookieOptions;
 export function getPKCECookieOptions(redirectUri: string | null | undefined, asString: true, expired?: boolean): string;
@@ -111,13 +114,16 @@ export function getPKCECookieOptions(
 ): CookieOptions | string {
   if (asString) {
     const options = getCookieOptions(redirectUri, true, expired);
-    return options.replace(/SameSite=Strict/i, 'SameSite=Lax');
+    return options
+      .replace(/SameSite=Strict/i, 'SameSite=Lax')
+      .replace(/Max-Age=\d+/, `Max-Age=${expired ? 0 : PKCE_COOKIE_MAX_AGE}`);
   }
 
   const options = getCookieOptions(redirectUri);
   return {
     ...options,
     sameSite: options.sameSite.toLowerCase() === 'strict' ? 'lax' : options.sameSite,
+    maxAge: expired ? 0 : PKCE_COOKIE_MAX_AGE,
   };
 }
 

--- a/src/pkce.spec.ts
+++ b/src/pkce.spec.ts
@@ -1,7 +1,28 @@
 import { sealData } from 'iron-session';
-import { getStateFromPKCECookieValue } from './pkce.js';
+import { getStateFromPKCECookieValue, getPKCECookieNameForState } from './pkce.js';
 
 const PASSWORD = process.env.WORKOS_COOKIE_PASSWORD!;
+
+describe('getPKCECookieNameForState', () => {
+  it('should derive a cookie name prefixed with the base name', () => {
+    const state = 'any-string-at-all';
+
+    expect(getPKCECookieNameForState(state)).toMatch(/^wos-auth-verifier-[0-9a-f]{8}$/);
+  });
+
+  it('should produce different names for different states', () => {
+    const stateA = 'first-sealed-state-value';
+    const stateB = 'second-sealed-state-value';
+
+    expect(getPKCECookieNameForState(stateA)).not.toBe(getPKCECookieNameForState(stateB));
+  });
+
+  it('should be deterministic for the same input', () => {
+    const state = 'some-sealed-state';
+
+    expect(getPKCECookieNameForState(state)).toBe(getPKCECookieNameForState(state));
+  });
+});
 
 describe('setPKCECookie SameSite override', () => {
   const mockSet = vi.fn();
@@ -26,7 +47,7 @@ describe('setPKCECookie SameSite override', () => {
     await setPKCECookie('sealed-state');
 
     expect(mockSet).toHaveBeenCalledWith(
-      'wos-auth-verifier',
+      getPKCECookieNameForState('sealed-state'),
       'sealed-state',
       expect.objectContaining({ sameSite: 'lax' }),
     );
@@ -40,7 +61,7 @@ describe('setPKCECookie SameSite override', () => {
     await setPKCECookie('sealed-state');
 
     expect(mockSet).toHaveBeenCalledWith(
-      'wos-auth-verifier',
+      getPKCECookieNameForState('sealed-state'),
       'sealed-state',
       expect.objectContaining({ sameSite: 'none' }),
     );
@@ -54,7 +75,7 @@ describe('setPKCECookie SameSite override', () => {
     await setPKCECookie('sealed-state');
 
     expect(mockSet).toHaveBeenCalledWith(
-      'wos-auth-verifier',
+      getPKCECookieNameForState('sealed-state'),
       'sealed-state',
       expect.objectContaining({ sameSite: 'lax' }),
     );
@@ -65,7 +86,7 @@ describe('setPKCECookie SameSite override', () => {
     await setPKCECookie('sealed-state');
 
     expect(mockSet).toHaveBeenCalledWith(
-      'wos-auth-verifier',
+      getPKCECookieNameForState('sealed-state'),
       'sealed-state',
       expect.objectContaining({ sameSite: 'lax' }),
     );

--- a/src/pkce.ts
+++ b/src/pkce.ts
@@ -1,3 +1,4 @@
+import fnv1a from '@sindresorhus/fnv1a';
 import { unsealData } from 'iron-session';
 import { cookies } from 'next/headers';
 import * as v from 'valibot';
@@ -9,6 +10,27 @@ export const PKCE_COOKIE_NAME = 'wos-auth-verifier';
 const PKCE_COOKIE_MAX_AGE = 600; // 10 minutes
 
 /**
+ * Short, deterministic hex fingerprint of an arbitrary string.
+ * Used to give each PKCE flow its own cookie name without depending
+ * on the internal format of the sealed state value
+ */
+function shortHash(input: string): string {
+  // fnv1a returns a BigInt — use 32-bit variant so it fits safely in a Number
+  const hash = Number(fnv1a(input, { size: 32 }));
+
+  // Hex-encode and pad to a fixed 8-char width
+  return hash.toString(16).padStart(8, '0');
+}
+
+/**
+ * Derive a flow-specific cookie name so concurrent auth flows don't overwrite
+ * each other's PKCE cookies. Uses an FNV-1a hash of the full sealed state
+ */
+export function getPKCECookieNameForState(state: string): string {
+  return `${PKCE_COOKIE_NAME}-${shortHash(state)}`;
+}
+
+/**
  * Set the PKCE verifier cookie in server action context.
  * In middleware context, callers must set the cookie via Set-Cookie headers instead.
  */
@@ -16,7 +38,7 @@ export async function setPKCECookie(sealedState: string): Promise<void> {
   const nextCookies = await cookies();
   const { domain, path, sameSite, secure } = getPKCECookieOptions();
 
-  nextCookies.set(PKCE_COOKIE_NAME, sealedState, {
+  nextCookies.set(getPKCECookieNameForState(sealedState), sealedState, {
     domain,
     path,
     sameSite,

--- a/src/pkce.ts
+++ b/src/pkce.ts
@@ -7,7 +7,6 @@ import { WORKOS_COOKIE_PASSWORD } from './env-variables.js';
 import { State, StateSchema } from './interfaces.js';
 
 export const PKCE_COOKIE_NAME = 'wos-auth-verifier';
-const PKCE_COOKIE_MAX_AGE = 600; // 10 minutes
 
 /**
  * Short, deterministic hex fingerprint of an arbitrary string.
@@ -36,15 +35,11 @@ export function getPKCECookieNameForState(state: string): string {
  */
 export async function setPKCECookie(sealedState: string): Promise<void> {
   const nextCookies = await cookies();
-  const { domain, path, sameSite, secure } = getPKCECookieOptions();
+  const options = getPKCECookieOptions();
 
   nextCookies.set(getPKCECookieNameForState(sealedState), sealedState, {
-    domain,
-    path,
-    sameSite,
-    secure,
+    ...options,
     httpOnly: true,
-    maxAge: PKCE_COOKIE_MAX_AGE,
   });
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -18,7 +18,7 @@ import {
   Session,
   UserInfo,
 } from './interfaces.js';
-import { PKCE_COOKIE_NAME, setPKCECookie } from './pkce.js';
+import { getPKCECookieNameForState, setPKCECookie } from './pkce.js';
 import { getWorkOS } from './workos.js';
 
 import type { AuthenticationResponse } from '@workos-inc/node';
@@ -26,8 +26,21 @@ import { parse, tokensToRegexp } from 'path-to-regexp';
 import { handleAuthkitHeaders } from './middleware-helpers.js';
 import { lazy, setCachePreventionHeaders } from './utils.js';
 
-function appendPKCESetCookieHeader(headers: Headers, sealedState: string, requestUrl: string): void {
-  headers.append('Set-Cookie', `${PKCE_COOKIE_NAME}=${sealedState}; ${getPKCECookieOptions(requestUrl, true)}`);
+// Only set the PKCE cookie for initial document navigations — fetch/XHR/RSC/prefetch
+// requests never follow cross-origin redirects so they'll never complete the OAuth
+// flow and therefore don't need the cookie set.
+// This prevents cookie bloat (HTTP 431) when multiple requests fire concurrently
+// now that we are generating unique cookie names per flow, they add up quickly if
+// we don't limit to just the initial navigation request
+function appendPKCESetCookieHeader(request: NextRequest, headers: Headers, sealedState: string): void {
+  if (!isInitialDocumentRequest(request)) {
+    return;
+  }
+
+  headers.append(
+    'Set-Cookie',
+    `${getPKCECookieNameForState(sealedState)}=${sealedState}; ${getPKCECookieOptions(request.url, true)}`,
+  );
 }
 
 const sessionHeaderName = 'x-workos-session';
@@ -213,7 +226,7 @@ async function updateSession(
       screenHint: options.screenHint,
     });
 
-    appendPKCESetCookieHeader(newRequestHeaders, sealedState, request.url);
+    appendPKCESetCookieHeader(request, newRequestHeaders, sealedState);
 
     return {
       session: { user: null },
@@ -354,7 +367,7 @@ async function updateSession(
       redirectUri: options.redirectUri || WORKOS_REDIRECT_URI,
     });
 
-    appendPKCESetCookieHeader(newRequestHeaders, sealedState, request.url);
+    appendPKCESetCookieHeader(request, newRequestHeaders, sealedState);
 
     return {
       session: { user: null },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -26,7 +26,7 @@ vi.mock('next/headers', () => {
         cookieStore.delete(cookieName);
       }),
       get: vi.fn((name: string) => cookieStore.get(name)),
-      getAll: vi.fn(() => Array.from(cookieStore.entries())),
+      getAll: vi.fn(() => Array.from(cookieStore.values())),
       set: vi.fn((name: string, value: string | { [key: string]: string | number | boolean }) =>
         cookieStore.set(name, {
           name,


### PR DESCRIPTION
When a user's session expires (e.g. inactivity timeout) and they have multiple tabs open all tabs wake up and fire requests simultaneously, or even if a single tab fires off multiple requests at once that trigger the auth flow. Each request hits the middleware, which generates a fresh PKCE state and overwrites the single shared `wos-auth-verifier` cookie. The last write wins, so when callbacks return from WorkOS, every tab except the last one fails with "OAuth state mismatch" or "Auth cookie missing".

This is reliably reproducible: open 3-4 tabs, wait for session expiry, switch back to the browser. The tabs wake up concurrently, each triggers a middleware redirect with a different PKCE state, and the shared cookie gets clobbered.

Two changes fix this:

1. Per-flow cookie names: derive a unique suffix from an FNV-1a hash of the sealed state (e.g. `wos-auth-verifier-a3f7c012`). Each concurrent flow gets its own cookie, and each callback reads the correct one. Uses @sindresorhus/fnv1a for a fast, format-agnostic 32-bit hash.

2. Document-only cookies: reuse the existing `isInitialDocumentRequest` check to only set PKCE cookies on full page navigations. Fetch, XHR, RSC, and prefetch requests never follow cross-origin redirects so they can never complete the OAuth flow. Without this guard, the per-flow cookie names cause many cookies per tab (one per concurrent request e.g., react-query reissuing XHR fetches on window activate), which quickly exceeds browser header limits and triggers HTTP 431 (Request Header Fields Too Large).