### PR TITLE
fix: set PKCE cookie in ensureSignedIn server action flow

### DIFF
--- a/src/actions.spec.ts
+++ b/src/actions.spec.ts
@@ -8,12 +8,12 @@ import {
   getAccessTokenAction,
   refreshAccessTokenAction,
 } from '../src/actions.js';
-import { signOut, switchToOrganization } from './auth.js';
+import { getSignInUrl, signOut, switchToOrganization } from './auth.js';
 import { getWorkOS } from '../src/workos.js';
 import { withAuth, refreshSession } from '../src/session.js';
-import { getAuthorizationUrl } from '../src/get-authorization-url.js';
 
 vi.mock('../src/auth.js', () => ({
+  getSignInUrl: vi.fn().mockResolvedValue('https://api.workos.com/authorize?...'),
   signOut: vi.fn().mockResolvedValue(true),
   switchToOrganization: vi.fn().mockResolvedValue({ organizationId: 'org_123' }),
 }));
@@ -32,10 +32,6 @@ vi.mock('../src/workos.js', () => ({
 vi.mock('../src/session.js', () => ({
   withAuth: vi.fn().mockResolvedValue({ user: 'testUser', accessToken: 'access_token' }),
   refreshSession: vi.fn().mockResolvedValue({ user: 'testUser', accessToken: 'refreshed_token' }),
-}));
-
-vi.mock('../src/get-authorization-url.js', () => ({
-  getAuthorizationUrl: vi.fn().mockResolvedValue('https://api.workos.com/authorize?...'),
 }));
 
 describe('actions', () => {
@@ -94,13 +90,13 @@ describe('actions', () => {
     it('should return signInUrl when ensureSignedIn is true and no user', async () => {
       vi.mocked(withAuth).mockResolvedValueOnce({ user: null });
       const result = await getAuthAction({ ensureSignedIn: true });
-      expect(getAuthorizationUrl).toHaveBeenCalledWith({ screenHint: 'sign-in' });
+      expect(getSignInUrl).toHaveBeenCalled();
       expect(result).toEqual({ user: null, signInUrl: 'https://api.workos.com/authorize?...' });
     });
 
     it('should not return signInUrl when ensureSignedIn is true and user exists', async () => {
       const result = await getAuthAction({ ensureSignedIn: true });
-      expect(getAuthorizationUrl).not.toHaveBeenCalled();
+      expect(getSignInUrl).not.toHaveBeenCalled();
       expect(result).toEqual({ user: 'testUser', sessionId: 'session_123' });
     });
   });
@@ -121,13 +117,13 @@ describe('actions', () => {
     it('should return signInUrl when ensureSignedIn is true and no user', async () => {
       vi.mocked(refreshSession).mockResolvedValueOnce({ user: null });
       const result = await refreshAuthAction({ ensureSignedIn: true });
-      expect(getAuthorizationUrl).toHaveBeenCalledWith({ screenHint: 'sign-in' });
+      expect(getSignInUrl).toHaveBeenCalled();
       expect(result).toEqual({ user: null, signInUrl: 'https://api.workos.com/authorize?...' });
     });
 
     it('should not return signInUrl when ensureSignedIn is true and user exists', async () => {
       const result = await refreshAuthAction({ ensureSignedIn: true });
-      expect(getAuthorizationUrl).not.toHaveBeenCalled();
+      expect(getSignInUrl).not.toHaveBeenCalled();
       expect(result).toEqual({ user: 'testUser', sessionId: 'session_123' });
     });
   });

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,9 +1,8 @@
 'use server';
 
-import { signOut, switchToOrganization } from './auth.js';
+import { getSignInUrl, signOut, switchToOrganization } from './auth.js';
 import { NoUserInfo, UserInfo, SwitchToOrganizationOptions } from './interfaces.js';
 import { refreshSession, withAuth } from './session.js';
-import { getAuthorizationUrl } from './get-authorization-url.js';
 import { getWorkOS } from './workos.js';
 
 export interface RefreshAccessTokenActionResult {
@@ -49,7 +48,7 @@ export const getAuthAction = async (options?: { ensureSignedIn?: boolean }) => {
   const sanitized = sanitize(auth);
 
   if (options?.ensureSignedIn && !auth.user) {
-    const signInUrl = await getAuthorizationUrl({ screenHint: 'sign-in' });
+    const signInUrl = await getSignInUrl();
     return { ...sanitized, signInUrl };
   }
 
@@ -69,7 +68,7 @@ export const refreshAuthAction = async ({
   const sanitized = sanitize(auth);
 
   if (ensureSignedIn && !auth.user) {
-    const signInUrl = await getAuthorizationUrl({ screenHint: 'sign-in' });
+    const signInUrl = await getSignInUrl();
     return { ...sanitized, signInUrl };
   }
 


### PR DESCRIPTION
## What

`getAuthAction` and `refreshAuthAction` in `src/actions.ts` were returning the raw `getAuthorizationUrl` result object (`{ url, sealedState }`) as `signInUrl`, and never called `setPKCECookie`. The client does `window.location.href = auth.signInUrl as string` in the provider, which coerces the object to `"[object Object]"` and navigates nowhere. Even if it had navigated, the callback would reject the flow because no `wos-auth-verifier` cookie was set.

Introduced by #386 (CORS fix). The test mock returned a plain string instead of the real `{ url, sealedState }` shape, so the bug slipped through.

## How

Both actions now call `getSignInUrl()` from `auth.ts`, which is the existing public wrapper that returns the URL string and sets the PKCE cookie in one step. Collapses two parallel code paths into one. Next time someone adds a property to the sign-in flow, there's only one place to update.

Test mock updated to match the real `getSignInUrl` contract.

## Notes

Separate from #403. That one fixed the concurrent-flow cookie clobber in middleware. This one is the server-action sign-in path, same shape of bug (missing PKCE side effect) but different call site.