### PR TITLE
chore!: Upgrade @workos-inc/node to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@sindresorhus/fnv1a": "^3.1.0",
-    "@workos-inc/node": "^8.9.0",
+    "@workos-inc/node": "^9.0.0",
     "iron-session": "^8.0.4",
     "jose": "^5.10.0",
     "path-to-regexp": "^6.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
       '@workos-inc/node':
-        specifier: ^8.9.0
-        version: 8.9.0
+        specifier: ^9.0.0
+        version: 9.1.0
       iron-session:
         specifier: ^8.0.4
         version: 8.0.4
@@ -2058,9 +2058,9 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@workos-inc/node@8.9.0':
-    resolution: {integrity: sha512-io5D4Scoy7RwjNQGyWWVeljwQz4RSqGRILP1/tbv5vXUxJdhpcGqGwML4AHamgacEay+QyiDW9RvgfjiQN3KLw==}
-    engines: {node: '>=20.15.0'}
+  '@workos-inc/node@9.1.0':
+    resolution: {integrity: sha512-moaQsCqnRqJS3AYMrST70lChSt3KI8J81C+PMNg0h67u5OqbHBVGZi8tEUVxughBfoQaRGgqgV+r/iFyWFFSPg==}
+    engines: {node: '>=22.11.0'}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -2418,6 +2418,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -5294,7 +5297,9 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@workos-inc/node@8.9.0': {}
+  '@workos-inc/node@9.1.0':
+    dependencies:
+      eventemitter3: 5.0.4
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -5645,6 +5650,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
+
+  eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
 

--- a/src/validate-api-key.spec.ts
+++ b/src/validate-api-key.spec.ts
@@ -16,7 +16,7 @@ describe('validate-api-key.ts', () => {
     nextHeaders._reset();
   });
 
-  describe('validateApiKey', () => {
+  describe('createValidation', () => {
     it('should return valid API key when Bearer token is present and valid', async () => {
       const mockApiKeyResponse = {
         apiKey: {
@@ -32,14 +32,14 @@ describe('validate-api-key.ts', () => {
         },
       };
 
-      vi.spyOn(workos.apiKeys, 'validateApiKey').mockResolvedValue(mockApiKeyResponse);
+      vi.spyOn(workos.apiKeys, 'createValidation').mockResolvedValue(mockApiKeyResponse);
 
       const nextHeaders = await headers();
       nextHeaders.set('authorization', 'Bearer sk_test_1234567890');
 
       const result = await validateApiKey();
 
-      expect(workos.apiKeys.validateApiKey).toHaveBeenCalledWith({
+      expect(workos.apiKeys.createValidation).toHaveBeenCalledWith({
         value: 'sk_test_1234567890',
       });
       expect(result).toEqual(mockApiKeyResponse);
@@ -49,7 +49,7 @@ describe('validate-api-key.ts', () => {
       // Don't set any authorization header
       const result = await validateApiKey();
 
-      expect(workos.apiKeys.validateApiKey).not.toHaveBeenCalled();
+      expect(workos.apiKeys.createValidation).not.toHaveBeenCalled();
       expect(result).toEqual({ apiKey: null });
     });
 
@@ -59,7 +59,7 @@ describe('validate-api-key.ts', () => {
 
       const result = await validateApiKey();
 
-      expect(workos.apiKeys.validateApiKey).not.toHaveBeenCalled();
+      expect(workos.apiKeys.createValidation).not.toHaveBeenCalled();
       expect(result).toEqual({ apiKey: null });
     });
 
@@ -69,7 +69,7 @@ describe('validate-api-key.ts', () => {
 
       const result = await validateApiKey();
 
-      expect(workos.apiKeys.validateApiKey).not.toHaveBeenCalled();
+      expect(workos.apiKeys.createValidation).not.toHaveBeenCalled();
       expect(result).toEqual({ apiKey: null });
     });
 
@@ -79,7 +79,7 @@ describe('validate-api-key.ts', () => {
 
       const result = await validateApiKey();
 
-      expect(workos.apiKeys.validateApiKey).not.toHaveBeenCalled();
+      expect(workos.apiKeys.createValidation).not.toHaveBeenCalled();
       expect(result).toEqual({ apiKey: null });
     });
 
@@ -89,20 +89,20 @@ describe('validate-api-key.ts', () => {
 
       const result = await validateApiKey();
 
-      expect(workos.apiKeys.validateApiKey).not.toHaveBeenCalled();
+      expect(workos.apiKeys.createValidation).not.toHaveBeenCalled();
       expect(result).toEqual({ apiKey: null });
     });
 
     it('should return { apiKey: null } when WorkOS validation fails', async () => {
       const mockResponse = { apiKey: null };
-      vi.spyOn(workos.apiKeys, 'validateApiKey').mockResolvedValue(mockResponse);
+      vi.spyOn(workos.apiKeys, 'createValidation').mockResolvedValue(mockResponse);
 
       const nextHeaders = await headers();
       nextHeaders.set('authorization', 'Bearer invalid_key');
 
       const result = await validateApiKey();
 
-      expect(workos.apiKeys.validateApiKey).toHaveBeenCalledWith({
+      expect(workos.apiKeys.createValidation).toHaveBeenCalledWith({
         value: 'invalid_key',
       });
       expect(result).toEqual({ apiKey: null });

--- a/src/validate-api-key.ts
+++ b/src/validate-api-key.ts
@@ -15,5 +15,5 @@ export async function validateApiKey() {
     return { apiKey: null };
   }
 
-  return getWorkOS().apiKeys.validateApiKey({ value });
+  return getWorkOS().apiKeys.createValidation({ value });
 }


### PR DESCRIPTION
## Summary
- Bump `@workos-inc/node` from v8 to v9
- Update `apiKeys.validateApiKey()` calls to `apiKeys.createValidation()` to match the renamed v9 SDK method
- Update tests to mock and assert against the new method name

## Test plan
- [ ] `pnpm test` passes (validate-api-key specs)
- [ ] Verify API key validation works end-to-end against a WorkOS environment running the v9 SDK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/workos/authkit-nextjs/pull/407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
