### PR TITLE
chore!: set minimum Node.js version to 22.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22, 24]
+        node: [22, 24]
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4

--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
   "bugs": {
     "url": "https://github.com/workos/authkit-nextjs/issues"
   },
+  "engines": {
+    "node": ">=22.11.0"
+  },
   "pnpm": {
     "overrides": {
       "glob@>=10 <10.5.0": ">=10.5.0"


### PR DESCRIPTION
## Summary
- Add `engines.node` constraint (>= 22.11.0) to `package.json` so npm/pnpm fails fast on unsupported Node versions
- Drop Node 20 from CI matrix to stop testing against a version that is no longer supported

## Test plan
- [ ] Verify `pnpm install` on Node < 22.11 warns or fails (depending on `engine-strict` setting)
- [ ] Verify CI runs only Node 22 and 24 matrix entries