### PR TITLE
fix: persist authenticationMethod in sealed session cookie

### DIFF
--- a/src/authkit-callback-route.spec.ts
+++ b/src/authkit-callback-route.spec.ts
@@ -321,6 +321,23 @@ describe('authkit-callback-route', () => {
       expect(session?.accessToken).toBe(mockAuthResponse.accessToken);
     });
 
+    it('should persist authenticationMethod in the sealed session', async () => {
+      vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue({
+        ...mockAuthResponse,
+        authenticationMethod: 'SSO',
+      });
+
+      const sealedState = await setAuthCookie(request, { nonce: 'foo', codeVerifier: 'test-verifier' });
+      request.nextUrl.searchParams.set('code', 'test-code');
+      request.nextUrl.searchParams.set('state', sealedState);
+
+      const handler = handleAuth();
+      await handler(request);
+
+      const session = await getSessionFromCookie();
+      expect(session?.authenticationMethod).toBe('SSO');
+    });
+
     it('should allow onSuccess to update session', async () => {
       const newAccessToken = 'new-access-token';
       vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue(mockAuthResponse);

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -103,7 +103,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
       // to avoid stale cookies affecting future auth attempts & prevent replays
       response.headers.append('Set-Cookie', `${pkceCookieName}=; ${getPKCECookieOptions(request.url, true, true)}`);
 
-      await saveSession({ accessToken, refreshToken, user, impersonator }, request);
+      await saveSession({ accessToken, refreshToken, user, impersonator, authenticationMethod }, request);
 
       if (onSuccess) {
         await onSuccess({

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,6 +25,7 @@ export interface Session {
   refreshToken: string;
   user: User;
   impersonator?: Impersonator;
+  authenticationMethod?: AuthenticationResponse['authenticationMethod'];
 }
 
 export interface UserInfo {

--- a/src/session.ts
+++ b/src/session.ts
@@ -291,7 +291,7 @@ async function updateSession(
 
     const { org_id: organizationIdFromAccessToken } = decodeJwt<AccessToken>(session.accessToken);
 
-    const { accessToken, refreshToken, user, impersonator } =
+    const { accessToken, refreshToken, user, impersonator, authenticationMethod } =
       await getWorkOS().userManagement.authenticateWithRefreshToken({
         clientId: WORKOS_CLIENT_ID,
         refreshToken: session.refreshToken,
@@ -307,6 +307,7 @@ async function updateSession(
       refreshToken,
       user,
       impersonator,
+      authenticationMethod,
     });
 
     newRequestHeaders.append('Set-Cookie', `${cookieName}=${encryptedSession}; ${getCookieOptions(request.url, true)}`);


### PR DESCRIPTION
## Summary

Fixes a bug where `authenticationMethod` is silently dropped before the session is sealed, so callers who unseal the cookie with `workos.userManagement.authenticateWithSessionCookie()` always see `authenticationMethod: undefined` — regardless of how the user actually signed in.

## The bug

`authenticateWithCode()` (and `authenticateWithRefreshToken()`) return an `AuthenticationResponse` that includes `authenticationMethod`. The callback route and the middleware refresh path both destructured the response, but then constructed a smaller object literal that omitted `authenticationMethod` before calling `saveSession(...)` / `encryptSession(...)`. The field never made it into the sealed cookie.

### Minimal reproduction

1. Sign in via SSO (or any other non-default method) through a route wired up with `handleAuth()`.
2. In a downstream route, read the cookie and call `workos.userManagement.authenticateWithSessionCookie({ sessionData: cookieValue, cookiePassword })`.
3. Inspect the returned session — `authenticationMethod` is `undefined` even though the user just authenticated with `SSO`.

## The fix

Two call sites, two one-line additions, plus a widening of the local `Session` interface:

- `src/authkit-callback-route.ts:106` — include `authenticationMethod` in the object passed to `saveSession(...)`.
- `src/session.ts` (`updateSession` middleware refresh path) — destructure `authenticationMethod` from the refresh response and include it in the `encryptSession(...)` payload.
- `src/interfaces.ts` — add the optional `authenticationMethod?: AuthenticationResponse['authenticationMethod']` field to the local `Session` interface so the object literals type-check. The Node SDK's `SessionCookieData` already includes this field as a `Pick` from `AuthenticationResponse`, so on-wire shape is unchanged.

The `refreshSession` path in `src/session.ts` was already correct — it forwards the entire `AuthenticationResponse` to `saveSession`, so `authenticationMethod` was already preserved there.

### Test

Added an assertion in `authkit-callback-route.spec.ts` that unseals the cookie after a successful callback and confirms `authenticationMethod` is present.

## Backwards compatibility

Safe:
- **Existing sealed sessions** will continue to return `authenticationMethod: undefined` until the user re-authenticates or their session is refreshed. No action required from consumers — it's the same value they were already getting.
- **New sessions** (and refreshed sessions) will carry the field correctly.
- `saveSession` / `encryptSession` perform no schema enforcement; they just seal whatever object they're given. Adding the field is non-breaking for any already-sealed cookie format.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (349 passing, including the new assertion)
- [x] `pnpm lint`
- [x] `pnpm format:check`