### PR TITLE
feat: Add feature flags runtime client helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,11 @@ const featureFlags = getFeatureFlagsRuntimeClient();
 export default async function DashboardPage() {
   const { user, organizationId } = await withAuth({ ensureSignedIn: true });
 
-  await featureFlags.waitUntilReady({ timeoutMs: 5000 });
+  try {
+    await featureFlags.waitUntilReady({ timeoutMs: 5000 });
+  } catch (error) {
+    console.error('Feature flags client failed to initialize:', error);
+  }
 
   const enabled = featureFlags.isEnabled('advanced-analytics', {
     userId: user.id,

--- a/README.md
+++ b/README.md
@@ -452,13 +452,47 @@ export default function MyComponent() {
 }
 ```
 
-### Get the enabled flags for the logged in user
+### Evaluate feature flags
 
-For situations where you need access to the authenticated user's currently active feature flags, use `withAuth` to retrieve the flags from the WorkOS session.
+There are two ways to evaluate feature flags with AuthKit Next.js:
+
+- Use the `feature_flags` access token claim when you want a simple session-scoped list of enabled flags for the signed-in user.
+- Use the Feature Flags runtime client when you want server-side evaluation without storing every active flag in the user's session cookie.
+
+#### Option 1: Use the `feature_flags` claim
+
+For situations where you need access to the authenticated user's currently active feature flags and your environment includes the `feature_flags` access token claim, use `withAuth` to retrieve the flags from the WorkOS session.
 
 ```jsx
 const { featureFlags } = await withAuth();
 ```
+
+This is convenient for small flag sets because the flags are available with the user's session. Flag changes appear the next time the user logs in or the session is refreshed.
+
+#### Option 2: Use the runtime client
+
+Use the runtime client when your application has many feature flags, when the `feature_flags` claim makes the access token too large, or when you need server-side flag evaluation that stays in sync independently of the user's session. The runtime client keeps flag configuration in memory and syncs changes in the background, so create one shared instance per server process rather than one client per request.
+
+```tsx
+import { getFeatureFlagsRuntimeClient, withAuth } from '@workos-inc/authkit-nextjs';
+
+const featureFlags = getFeatureFlagsRuntimeClient();
+
+export default async function DashboardPage() {
+  const { user, organizationId } = await withAuth({ ensureSignedIn: true });
+
+  await featureFlags.waitUntilReady({ timeoutMs: 5000 });
+
+  const enabled = featureFlags.isEnabled('advanced-analytics', {
+    userId: user.id,
+    organizationId,
+  });
+
+  return enabled ? <AdvancedAnalytics /> : <BasicAnalytics />;
+}
+```
+
+The `getFeatureFlagsRuntimeClient` helper returns the same runtime client for every call in the current server process. Options passed to `getFeatureFlagsRuntimeClient(options)` are only used when the client is created for the first time.
 
 ### Requiring auth
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,7 @@
   "extends": ["github>workos/renovate-config"],
   "enabledManagers": ["github-actions"],
   "dependencyDashboard": false,
-  "schedule": [
-    "on the 15th day of the month before 12pm"
-  ],
+  "schedule": ["on the 15th day of the month before 12pm"],
   "timezone": "UTC",
-  "rebaseWhen": "conflicted",
+  "rebaseWhen": "conflicted"
 }

--- a/src/feature-flags.spec.ts
+++ b/src/feature-flags.spec.ts
@@ -3,6 +3,7 @@ import { getWorkOS } from './workos.js';
 describe('feature flags', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.resetModules();
   });
 
   it('memoizes the feature flags runtime client', async () => {

--- a/src/feature-flags.spec.ts
+++ b/src/feature-flags.spec.ts
@@ -1,0 +1,27 @@
+import { getWorkOS } from './workos.js';
+
+describe('feature flags', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('memoizes the feature flags runtime client', async () => {
+    const runtimeClient = {
+      close: vi.fn(),
+      getAllFlags: vi.fn(),
+      getFlag: vi.fn(),
+      getStats: vi.fn(),
+      isEnabled: vi.fn(),
+      waitUntilReady: vi.fn(),
+    };
+    const createRuntimeClient = vi
+      .spyOn(getWorkOS().featureFlags, 'createRuntimeClient')
+      .mockReturnValue(runtimeClient as never);
+    const { getFeatureFlagsRuntimeClient } = await import('./feature-flags.js');
+
+    expect(getFeatureFlagsRuntimeClient({ pollingIntervalMs: 5000 })).toBe(runtimeClient);
+    expect(getFeatureFlagsRuntimeClient({ pollingIntervalMs: 30000 })).toBe(runtimeClient);
+    expect(createRuntimeClient).toHaveBeenCalledTimes(1);
+    expect(createRuntimeClient).toHaveBeenCalledWith({ pollingIntervalMs: 5000 });
+  });
+});

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -1,7 +1,6 @@
 import type { FeatureFlagsRuntimeClient, RuntimeClientOptions } from '@workos-inc/node';
+import { lazy } from './utils.js';
 import { getWorkOS } from './workos.js';
-
-let featureFlagsRuntimeClient: FeatureFlagsRuntimeClient | undefined;
 
 /**
  * Returns a shared WorkOS Feature Flags runtime client.
@@ -10,8 +9,7 @@ let featureFlagsRuntimeClient: FeatureFlagsRuntimeClient | undefined;
  * should be created once per server process instead of once per request.
  * Options are only used when the client is created for the first time.
  */
-export function getFeatureFlagsRuntimeClient(options?: RuntimeClientOptions): FeatureFlagsRuntimeClient {
-  featureFlagsRuntimeClient ??= getWorkOS().featureFlags.createRuntimeClient(options);
-
-  return featureFlagsRuntimeClient;
-}
+export const getFeatureFlagsRuntimeClient = lazy(
+  (options?: RuntimeClientOptions): FeatureFlagsRuntimeClient =>
+    getWorkOS().featureFlags.createRuntimeClient(options),
+);

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -1,0 +1,17 @@
+import type { FeatureFlagsRuntimeClient, RuntimeClientOptions } from '@workos-inc/node';
+import { getWorkOS } from './workos.js';
+
+let featureFlagsRuntimeClient: FeatureFlagsRuntimeClient | undefined;
+
+/**
+ * Returns a shared WorkOS Feature Flags runtime client.
+ *
+ * The runtime client keeps feature flag state in sync in the background, so it
+ * should be created once per server process instead of once per request.
+ * Options are only used when the client is created for the first time.
+ */
+export function getFeatureFlagsRuntimeClient(options?: RuntimeClientOptions): FeatureFlagsRuntimeClient {
+  featureFlagsRuntimeClient ??= getWorkOS().featureFlags.createRuntimeClient(options);
+
+  return featureFlagsRuntimeClient;
+}

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -10,6 +10,5 @@ import { getWorkOS } from './workos.js';
  * Options are only used when the client is created for the first time.
  */
 export const getFeatureFlagsRuntimeClient = lazy(
-  (options?: RuntimeClientOptions): FeatureFlagsRuntimeClient =>
-    getWorkOS().featureFlags.createRuntimeClient(options),
+  (options?: RuntimeClientOptions): FeatureFlagsRuntimeClient => getWorkOS().featureFlags.createRuntimeClient(options),
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export {
 } from './middleware-helpers.js';
 import { getTokenClaims, refreshSession, saveSession, withAuth } from './session.js';
 import { validateApiKey } from './validate-api-key.js';
+import { getFeatureFlagsRuntimeClient } from './feature-flags.js';
 import { getWorkOS } from './workos.js';
 
 export * from './interfaces.js';
@@ -28,6 +29,7 @@ export {
   authkitProxy,
   getSignInUrl,
   getSignUpUrl,
+  getFeatureFlagsRuntimeClient,
   getTokenClaims,
   getWorkOS,
   handleAuth,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,12 +38,12 @@ export function errorResponseWithFallback(errorBody: { error: { message: string;
  * @param fn - The function to be called once.
  * @returns A function that can only be called once.
  */
-export function lazy<T>(fn: () => T): () => T {
+export function lazy<TArgs extends unknown[], TResult>(fn: (...args: TArgs) => TResult): (...args: TArgs) => TResult {
   let called = false;
-  let result: T;
-  return () => {
+  let result: TResult;
+  return (...args: TArgs) => {
     if (!called) {
-      result = fn();
+      result = fn(...args);
       called = true;
     }
     return result;


### PR DESCRIPTION
## Summary
- add a memoized helper for the WorkOS Feature Flags runtime client
- document both feature flag evaluation paths: access token claim and runtime client
- add a focused test for runtime client memoization

## Tests
- corepack pnpm@10.28.0 test src/feature-flags.spec.ts
- corepack pnpm@10.28.0 run typecheck
- corepack pnpm@10.28.0 run lint
- corepack pnpm@10.28.0 exec oxfmt --check README.md src/index.ts src/feature-flags.ts src/feature-flags.spec.ts