### PR TITLE
fix: defer PKCE cookie write until AuthKit redirect

### DIFF
--- a/src/middleware-helpers.spec.ts
+++ b/src/middleware-helpers.spec.ts
@@ -7,6 +7,7 @@ import {
   isAuthkitRequestHeader,
   AUTHKIT_REQUEST_HEADERS,
 } from './middleware-helpers.js';
+import { appendPKCESetCookieHeader, setPendingPKCERedirectHeaders } from './pkce.js';
 
 describe('middleware-helpers', () => {
   function createMockRequest(url = 'https://example.com/test', method = 'GET'): NextRequest {
@@ -210,6 +211,42 @@ describe('middleware-helpers', () => {
 
       expect(handleAuthkitHeaders(request, headers, { redirect: '' }).status).toBe(200);
       expect(handleAuthkitHeaders(request, headers, { redirect: undefined }).status).toBe(200);
+    });
+
+    it('should set pending PKCE cookie when redirecting to the generated authorization URL', () => {
+      const request = new NextRequest('https://example.com/app', {
+        headers: { accept: 'text/html' },
+      });
+      const authorizationUrl = 'https://api.workos.com/user_management/authorize?client_id=client_123&state=abc';
+      const headers = new Headers();
+      setPendingPKCERedirectHeaders(headers, authorizationUrl, 'sealed-state');
+      appendPKCESetCookieHeader(request, headers, 'sealed-state');
+
+      const response = handleAuthkitHeaders(request, headers, { redirect: authorizationUrl });
+      const setCookies = response.headers.getSetCookie();
+
+      expect(setCookies.filter((c) => /^wos-auth-verifier-[0-9a-f]{8}=sealed-state;/.test(c))).toHaveLength(1);
+      expect(response.headers.get('x-workos-pkce-state')).toBeNull();
+      expect(response.headers.get('x-workos-authorization-url')).toBeNull();
+    });
+
+    it('should not set pending PKCE cookie without a matching AuthKit redirect', () => {
+      const request = new NextRequest('https://example.com/app', {
+        headers: { accept: 'text/html' },
+      });
+      const authorizationUrl = 'https://api.workos.com/user_management/authorize?client_id=client_123&state=abc';
+      const headers = new Headers();
+      setPendingPKCERedirectHeaders(headers, authorizationUrl, 'sealed-state');
+      appendPKCESetCookieHeader(request, headers, 'sealed-state');
+      headers.append('Set-Cookie', 'other=value; Path=/; HttpOnly');
+
+      const nextResponse = handleAuthkitHeaders(request, headers);
+      const customRedirectResponse = handleAuthkitHeaders(request, headers, { redirect: '/new-path' });
+
+      expect(nextResponse.headers.getSetCookie().some((c) => c.includes('wos-auth-verifier'))).toBe(false);
+      expect(customRedirectResponse.headers.getSetCookie().some((c) => c.includes('wos-auth-verifier'))).toBe(false);
+      expect(nextResponse.headers.getSetCookie().some((c) => c.startsWith('other=value;'))).toBe(true);
+      expect(customRedirectResponse.headers.getSetCookie().some((c) => c.startsWith('other=value;'))).toBe(true);
     });
   });
 

--- a/src/middleware-helpers.ts
+++ b/src/middleware-helpers.ts
@@ -1,4 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
+import {
+  PKCE_AUTHORIZATION_URL_HEADER,
+  PKCE_STATE_HEADER,
+  appendPKCESetCookieHeader,
+  stripPKCESetCookieHeaders,
+} from './pkce.js';
 
 /** Internal AuthKit headers - forwarded to downstream requests but never sent to browser. */
 export const AUTHKIT_REQUEST_HEADERS = [
@@ -112,16 +118,31 @@ export function handleAuthkitProxy(
   authkitHeaders: Headers,
   options: HandleAuthkitHeadersOptions = {},
 ): NextResponse {
-  const { requestHeaders, responseHeaders } = partitionAuthkitHeaders(request, authkitHeaders);
   const { redirect, redirectStatus } = options;
+  const headers = new Headers(authkitHeaders);
+  let redirectUrl: URL | undefined;
+
+  const pkceAuthorizationUrl = headers.get(PKCE_AUTHORIZATION_URL_HEADER);
+  const sealedState = headers.get(PKCE_STATE_HEADER);
+  if (pkceAuthorizationUrl && sealedState) {
+    stripPKCESetCookieHeaders(headers);
+  }
 
   if (redirect != null && redirect !== '') {
-    let redirectUrl: URL;
     try {
       redirectUrl = redirect instanceof URL ? redirect : new URL(redirect, request.url);
     } catch {
       throw new Error(`Invalid redirect URL: "${redirect}". Must be a valid absolute or relative URL.`);
     }
+
+    if (pkceAuthorizationUrl && sealedState && redirectUrl.toString() === new URL(pkceAuthorizationUrl).toString()) {
+      appendPKCESetCookieHeader(request, headers, sealedState);
+    }
+  }
+
+  const { requestHeaders, responseHeaders } = partitionAuthkitHeaders(request, headers);
+
+  if (redirectUrl) {
     const method = request.method.toUpperCase();
     const status = redirectStatus ?? (method === 'GET' || method === 'HEAD' ? 307 : 303);
     return applyResponseHeaders(NextResponse.redirect(redirectUrl, status), responseHeaders);

--- a/src/pkce.ts
+++ b/src/pkce.ts
@@ -102,7 +102,7 @@ export function stripPKCESetCookieHeaders(headers: Headers): void {
   }
 }
 
-function isInitialDocumentRequest(request: NextRequest): boolean {
+export function isInitialDocumentRequest(request: NextRequest): boolean {
   const accept = request.headers.get('accept') || '';
   const isDocumentRequest = accept.includes('text/html');
   const isRSCRequest = request.headers.has('RSC') || request.headers.has('Next-Router-State-Tree');

--- a/src/pkce.ts
+++ b/src/pkce.ts
@@ -1,12 +1,17 @@
 import fnv1a from '@sindresorhus/fnv1a';
 import { unsealData } from 'iron-session';
 import { cookies } from 'next/headers';
+import { NextRequest } from 'next/server';
 import * as v from 'valibot';
 import { getPKCECookieOptions } from './cookie.js';
 import { WORKOS_COOKIE_PASSWORD } from './env-variables.js';
 import { State, StateSchema } from './interfaces.js';
 
 export const PKCE_COOKIE_NAME = 'wos-auth-verifier';
+export const PKCE_STATE_HEADER = 'x-workos-pkce-state';
+export const PKCE_AUTHORIZATION_URL_HEADER = 'x-workos-authorization-url';
+
+const MAX_PKCE_COOKIES = 5;
 
 /**
  * Short, deterministic hex fingerprint of an arbitrary string.
@@ -41,6 +46,81 @@ export async function setPKCECookie(sealedState: string): Promise<void> {
     ...options,
     httpOnly: true,
   });
+}
+
+/**
+ * Store pending PKCE state in internal middleware headers until the response
+ * actually redirects to AuthKit. These headers are stripped before reaching the
+ * browser or downstream request handlers.
+ */
+export function setPendingPKCERedirectHeaders(headers: Headers, authorizationUrl: string, sealedState: string): void {
+  headers.set(PKCE_AUTHORIZATION_URL_HEADER, authorizationUrl);
+  headers.set(PKCE_STATE_HEADER, sealedState);
+}
+
+/**
+ * Only set the PKCE cookie for initial document navigations that redirect to
+ * AuthKit. Fetch/XHR/RSC/prefetch requests never follow cross-origin redirects
+ * to complete OAuth, so they do not need verifier cookies.
+ */
+export function appendPKCESetCookieHeader(request: NextRequest, headers: Headers, sealedState: string): void {
+  if (!isInitialDocumentRequest(request)) {
+    return;
+  }
+
+  const newCookieName = getPKCECookieNameForState(sealedState);
+  const pkceCookies = request.cookies
+    .getAll()
+    .filter(({ name }) => name === PKCE_COOKIE_NAME || name.startsWith(`${PKCE_COOKIE_NAME}-`));
+
+  // A small number of concurrent PKCE cookies is normal (multiple tabs each
+  // starting an OAuth flow). Only purge when accumulation risks HTTP 431.
+  if (pkceCookies.length >= MAX_PKCE_COOKIES) {
+    const expiredOptions = getPKCECookieOptions(request.url, true, true);
+    for (const { name } of pkceCookies) {
+      if (name !== newCookieName) {
+        headers.append('Set-Cookie', `${name}=; ${expiredOptions}`);
+      }
+    }
+  }
+
+  headers.append('Set-Cookie', `${newCookieName}=${sealedState}; ${getPKCECookieOptions(request.url, true)}`);
+}
+
+export function stripPKCESetCookieHeaders(headers: Headers): void {
+  const setCookieHeaders = headers.getSetCookie();
+  if (setCookieHeaders.length === 0) {
+    return;
+  }
+
+  headers.delete('Set-Cookie');
+
+  for (const setCookieHeader of setCookieHeaders) {
+    if (!isPKCESetCookieHeader(setCookieHeader)) {
+      headers.append('Set-Cookie', setCookieHeader);
+    }
+  }
+}
+
+function isInitialDocumentRequest(request: NextRequest): boolean {
+  const accept = request.headers.get('accept') || '';
+  const isDocumentRequest = accept.includes('text/html');
+  const isRSCRequest = request.headers.has('RSC') || request.headers.has('Next-Router-State-Tree');
+  const isPrefetch =
+    request.headers.get('Purpose') === 'prefetch' ||
+    request.headers.get('Sec-Purpose') === 'prefetch' ||
+    request.headers.has('Next-Router-Prefetch');
+
+  return isDocumentRequest && !isRSCRequest && !isPrefetch;
+}
+
+function isPKCESetCookieHeader(setCookieHeader: string): boolean {
+  const separatorIndex = setCookieHeader.indexOf('=');
+  if (separatorIndex === -1) {
+    return false;
+  }
+  const cookieName = setCookieHeader.slice(0, separatorIndex);
+  return cookieName === PKCE_COOKIE_NAME || cookieName.startsWith(`${PKCE_COOKIE_NAME}-`);
 }
 
 /**

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -16,6 +16,7 @@ function setEnvVar(mod: Record<string, unknown>, key: string, value: unknown) {
 import { sealData } from 'iron-session';
 import { User } from '@workos-inc/node';
 import { getStateFromPKCECookieValue } from './pkce.js';
+import { handleAuthkitHeaders } from './middleware-helpers.js';
 
 vi.mock('jose', async () => {
   const actual = await vi.importActual<typeof import('jose')>('jose');
@@ -615,7 +616,10 @@ describe('session.ts', () => {
 
   describe('updateSession', () => {
     it('should return an authorization url if the session is invalid', async () => {
-      const result = await updateSession(new NextRequest(new URL('http://example.com/protected')), {
+      const request = new NextRequest(new URL('http://example.com/protected'), {
+        headers: { accept: 'text/html' },
+      });
+      const result = await updateSession(request, {
         debug: true,
         screenHint: 'sign-up',
       });
@@ -623,6 +627,12 @@ describe('session.ts', () => {
       expect(result.authorizationUrl).toBeDefined();
       expect(result.authorizationUrl).toContain('screen_hint=sign-up');
       expect(result.session.user).toBeNull();
+      expect(result.headers.getSetCookie().some((c) => c.includes('wos-auth-verifier'))).toBe(true);
+      expect(
+        handleAuthkitHeaders(request, result.headers)
+          .headers.getSetCookie()
+          .some((c) => c.includes('wos-auth-verifier')),
+      ).toBe(false);
       expect(console.log).toHaveBeenCalledWith('No session found from cookie');
     });
 
@@ -696,6 +706,134 @@ describe('session.ts', () => {
       expect(response.session.user).toBeNull();
       expect(response.authorizationUrl).toBeDefined();
       expect(console.log).toHaveBeenCalledWith('Failed to refresh. Deleting cookie.', expect.any(Error));
+    });
+
+    describe('PKCE cookie cleanup', () => {
+      function documentRequest(url = 'http://example.com/protected'): NextRequest {
+        return new NextRequest(new URL(url), {
+          headers: { accept: 'text/html' },
+        });
+      }
+
+      function getRedirectSetCookieHeaders(
+        request: NextRequest,
+        result: Awaited<ReturnType<typeof updateSession>>,
+      ): string[] {
+        return handleAuthkitHeaders(request, result.headers, {
+          redirect: result.authorizationUrl,
+        }).headers.getSetCookie();
+      }
+
+      function addStalePKCECookies(request: NextRequest, count: number): void {
+        for (let i = 0; i < count; i++) {
+          request.cookies.set(`wos-auth-verifier-${i.toString(16).padStart(8, '0')}`, `stale-state-${i}`);
+        }
+      }
+
+      it('should not expire PKCE cookies when below the threshold (concurrent flows preserved)', async () => {
+        const request = documentRequest();
+        request.cookies.set('wos-auth-verifier-aaaaaaaa', 'stale-sealed-state-a');
+        request.cookies.set('wos-auth-verifier-bbbbbbbb', 'stale-sealed-state-b');
+
+        const result = await updateSession(request);
+
+        expect(result.session.user).toBeNull();
+        const setCookies = getRedirectSetCookieHeaders(request, result);
+        expect(setCookies.some((c) => c.startsWith('wos-auth-verifier-aaaaaaaa=;'))).toBe(false);
+        expect(setCookies.some((c) => c.startsWith('wos-auth-verifier-bbbbbbbb=;'))).toBe(false);
+        // The new PKCE cookie should still be set
+        expect(
+          setCookies.some(
+            (c) =>
+              c.match(/^wos-auth-verifier-[0-9a-f]{8}=.+/) &&
+              !c.startsWith('wos-auth-verifier-aaaaaaaa') &&
+              !c.startsWith('wos-auth-verifier-bbbbbbbb'),
+          ),
+        ).toBe(true);
+      });
+
+      it('should expire all PKCE cookies when at or above the threshold', async () => {
+        const request = documentRequest();
+        addStalePKCECookies(request, 5);
+
+        const result = await updateSession(request);
+
+        expect(result.session.user).toBeNull();
+        const setCookies = getRedirectSetCookieHeaders(request, result);
+        for (let i = 0; i < 5; i++) {
+          const name = `wos-auth-verifier-${i.toString(16).padStart(8, '0')}`;
+          expect(setCookies.some((c) => c.startsWith(`${name}=;`))).toBe(true);
+        }
+        // The new PKCE cookie should also be present
+        expect(setCookies.some((c) => c.match(/^wos-auth-verifier-[0-9a-f]{8}=.+/) && !c.includes('=;'))).toBe(true);
+      });
+
+      it('should expire stale PKCE cookies when refresh fails and threshold exceeded', async () => {
+        mockSession.accessToken = await generateTestToken({}, true);
+
+        (jwtVerify as Mock).mockImplementation(() => {
+          throw new Error('Invalid token');
+        });
+
+        vi.spyOn(workos.userManagement, 'authenticateWithRefreshToken').mockRejectedValue(new Error('Refresh failed'));
+
+        const request = documentRequest();
+        request.cookies.set(
+          'wos-session',
+          await sealData(mockSession, { password: process.env.WORKOS_COOKIE_PASSWORD as string }),
+        );
+        addStalePKCECookies(request, 5);
+
+        const result = await updateSession(request);
+
+        expect(result.session.user).toBeNull();
+        const setCookies = getRedirectSetCookieHeaders(request, result);
+        expect(setCookies.some((c) => c.startsWith('wos-auth-verifier-00000000=;'))).toBe(true);
+      });
+
+      it('should not expire PKCE cookies for non-document requests', async () => {
+        const request = new NextRequest(new URL('http://example.com/protected'), {
+          headers: { RSC: '1' },
+        });
+        addStalePKCECookies(request, 10);
+
+        const result = await updateSession(request);
+
+        const setCookies = getRedirectSetCookieHeaders(request, result);
+        expect(setCookies.some((c) => c.includes('wos-auth-verifier'))).toBe(false);
+      });
+
+      it('should not expire non-PKCE cookies', async () => {
+        const request = documentRequest();
+        request.cookies.set('some-other-cookie', 'value');
+        addStalePKCECookies(request, 5);
+
+        const result = await updateSession(request);
+
+        const setCookies = getRedirectSetCookieHeaders(request, result);
+        expect(setCookies.some((c) => c.startsWith('some-other-cookie=;'))).toBe(false);
+      });
+
+      it('should not expire legacy wos-auth-verifier cookie when below threshold', async () => {
+        const request = documentRequest();
+        request.cookies.set('wos-auth-verifier', 'legacy-sealed-state');
+
+        const result = await updateSession(request);
+
+        const setCookies = getRedirectSetCookieHeaders(request, result);
+        expect(setCookies.some((c) => c.startsWith('wos-auth-verifier=;'))).toBe(false);
+      });
+
+      it('should expire legacy wos-auth-verifier cookie when threshold exceeded', async () => {
+        const request = documentRequest();
+        request.cookies.set('wos-auth-verifier', 'legacy-sealed-state');
+        addStalePKCECookies(request, 5);
+
+        const result = await updateSession(request);
+
+        const setCookies = getRedirectSetCookieHeaders(request, result);
+        expect(setCookies.some((c) => c.startsWith('wos-auth-verifier=;'))).toBe(true);
+      });
     });
 
     it('should call onSessionRefreshSuccess when refresh succeeds', async () => {

--- a/src/session.ts
+++ b/src/session.ts
@@ -18,7 +18,12 @@ import {
   Session,
   UserInfo,
 } from './interfaces.js';
-import { appendPKCESetCookieHeader, isInitialDocumentRequest, setPKCECookie, setPendingPKCERedirectHeaders } from './pkce.js';
+import {
+  appendPKCESetCookieHeader,
+  isInitialDocumentRequest,
+  setPKCECookie,
+  setPendingPKCERedirectHeaders,
+} from './pkce.js';
 import { getWorkOS } from './workos.js';
 
 import type { AuthenticationResponse } from '@workos-inc/node';
@@ -75,7 +80,6 @@ function applyCacheSecurityHeaders(
 
   setCachePreventionHeaders(headers);
 }
-
 
 async function encryptSession(session: Session) {
   return sealData(session, {

--- a/src/session.ts
+++ b/src/session.ts
@@ -5,7 +5,7 @@ import { JWTPayload, createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose';
 import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { NextRequest } from 'next/server';
-import { getCookieOptions, getJwtCookie, getPKCECookieOptions } from './cookie.js';
+import { getCookieOptions, getJwtCookie } from './cookie.js';
 import { WORKOS_CLIENT_ID, WORKOS_COOKIE_NAME, WORKOS_COOKIE_PASSWORD, WORKOS_REDIRECT_URI } from './env-variables.js';
 import { TokenRefreshError, getSessionErrorContext } from './errors.js';
 import { getAuthorizationUrl } from './get-authorization-url.js';
@@ -18,30 +18,13 @@ import {
   Session,
   UserInfo,
 } from './interfaces.js';
-import { getPKCECookieNameForState, setPKCECookie } from './pkce.js';
+import { appendPKCESetCookieHeader, setPKCECookie, setPendingPKCERedirectHeaders } from './pkce.js';
 import { getWorkOS } from './workos.js';
 
 import type { AuthenticationResponse } from '@workos-inc/node';
 import { parse, tokensToRegexp } from 'path-to-regexp';
 import { handleAuthkitHeaders } from './middleware-helpers.js';
 import { lazy, setCachePreventionHeaders } from './utils.js';
-
-// Only set the PKCE cookie for initial document navigations — fetch/XHR/RSC/prefetch
-// requests never follow cross-origin redirects so they'll never complete the OAuth
-// flow and therefore don't need the cookie set.
-// This prevents cookie bloat (HTTP 431) when multiple requests fire concurrently
-// now that we are generating unique cookie names per flow, they add up quickly if
-// we don't limit to just the initial navigation request
-function appendPKCESetCookieHeader(request: NextRequest, headers: Headers, sealedState: string): void {
-  if (!isInitialDocumentRequest(request)) {
-    return;
-  }
-
-  headers.append(
-    'Set-Cookie',
-    `${getPKCECookieNameForState(sealedState)}=${sealedState}; ${getPKCECookieOptions(request.url, true)}`,
-  );
-}
 
 const sessionHeaderName = 'x-workos-session';
 const middlewareHeaderName = 'x-workos-middleware';
@@ -226,6 +209,7 @@ async function updateSession(
       screenHint: options.screenHint,
     });
 
+    setPendingPKCERedirectHeaders(newRequestHeaders, authorizationUrl, sealedState);
     appendPKCESetCookieHeader(request, newRequestHeaders, sealedState);
 
     return {
@@ -368,6 +352,7 @@ async function updateSession(
       redirectUri: options.redirectUri || WORKOS_REDIRECT_URI,
     });
 
+    setPendingPKCERedirectHeaders(newRequestHeaders, authorizationUrl, sealedState);
     appendPKCESetCookieHeader(request, newRequestHeaders, sealedState);
 
     return {

--- a/src/session.ts
+++ b/src/session.ts
@@ -18,7 +18,7 @@ import {
   Session,
   UserInfo,
 } from './interfaces.js';
-import { appendPKCESetCookieHeader, setPKCECookie, setPendingPKCERedirectHeaders } from './pkce.js';
+import { appendPKCESetCookieHeader, isInitialDocumentRequest, setPKCECookie, setPendingPKCERedirectHeaders } from './pkce.js';
 import { getWorkOS } from './workos.js';
 
 import type { AuthenticationResponse } from '@workos-inc/node';
@@ -76,20 +76,6 @@ function applyCacheSecurityHeaders(
   setCachePreventionHeaders(headers);
 }
 
-/**
- * Determines if a request is for an initial document load (not API/RSC/prefetch)
- */
-function isInitialDocumentRequest(request: NextRequest): boolean {
-  const accept = request.headers.get('accept') || '';
-  const isDocumentRequest = accept.includes('text/html');
-  const isRSCRequest = request.headers.has('RSC') || request.headers.has('Next-Router-State-Tree');
-  const isPrefetch =
-    request.headers.get('Purpose') === 'prefetch' ||
-    request.headers.get('Sec-Purpose') === 'prefetch' ||
-    request.headers.has('Next-Router-Prefetch');
-
-  return isDocumentRequest && !isRSCRequest && !isPrefetch;
-}
 
 async function encryptSession(session: Session) {
   return sealData(session, {


### PR DESCRIPTION
## Summary

- Middleware previously wrote a new `wos-auth-verifier-{hash}` cookie on **every request** without a session. Because each flow produces a uniquely named cookie, repeated page loads (e.g., refreshing while signed out) accumulated cookies until request headers exceeded server limits (HTTP 431).
- Instead of writing the cookie speculatively, the sealed PKCE state is now stashed in internal middleware headers (`x-workos-pkce-state`, `x-workos-authorization-url`). The actual `Set-Cookie` is only emitted when `handleAuthkitHeaders` redirects to the matching AuthKit authorization URL. No redirect → no cookie → no accumulation.
- For backward compatibility with `authkit()` users who forward headers manually without `handleAuthkitHeaders`, the speculative `Set-Cookie` is still included in the raw headers. `handleAuthkitHeaders` strips it on non-redirect responses via `stripPKCESetCookieHeaders`, so the recommended path never accumulates.
- A threshold-based cleanup (`MAX_PKCE_COOKIES=5`) is kept as a safety net for cookies created via server actions (`signIn`, `switchToOrganization`) which use `setPKCECookie` directly.