### PR TITLE
fix: expose interfaces package subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
       "types": "./dist/esm/types/components/index.d.ts",
       "import": "./dist/esm/components/index.js"
     },
+    "./interfaces": {
+      "types": "./dist/esm/types/interfaces.d.ts",
+      "import": "./dist/esm/interfaces.js"
+    },
     ".": {
       "types": "./dist/esm/types/index.d.ts",
       "import": "./dist/esm/index.js"


### PR DESCRIPTION
Adds a side-effect-free `./interfaces` package subpath so consumers can import `StateSchema` without touching the main Next/server entrypoint.

The existing build already emits:
- `dist/esm/interfaces.js`
- `dist/esm/types/interfaces.d.ts`

Verification:
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm typecheck`
- `corepack pnpm test` (359 passed)
- `./node_modules/.bin/tsc.cmd --project tsconfig.app.json` (used directly because the local Windows machine cannot install the global pnpm shim under `C:\Program Files\nodejs`)
- Consumer smoke test: `import { StateSchema } from "@workos-inc/authkit-nextjs/interfaces"` returns an object