### PR TITLE
test: pin callback redirect to the app origin

### DIFF
--- a/src/authkit-callback-route.spec.ts
+++ b/src/authkit-callback-route.spec.ts
@@ -243,6 +243,7 @@ describe('authkit-callback-route', () => {
       const appOrigin = 'http://example.com';
       const hostileReturnPathnames = [
         'javascript:alert(document.domain)',
+        'data:text/html,<script>alert(1)</script>',
         'https://evil.com/phishing',
         '//evil.com/phishing',
         '/\\evil.com/phishing',

--- a/src/authkit-callback-route.spec.ts
+++ b/src/authkit-callback-route.spec.ts
@@ -233,6 +233,49 @@ describe('authkit-callback-route', () => {
       expect(location).not.toContain('https://example.com/invite');
     });
 
+    // Regression coverage for the open-redirect / javascript:-URI class reported
+    // against the `state` param. `returnPathname` is read only from the sealed
+    // (tamper-proof) PKCE cookie and the callback copies only the pathname +
+    // search onto the app's own origin, so a hostile value can never change the
+    // redirect's scheme or host. These tests pin that invariant so a refactor
+    // that started honoring the full URL would fail loudly.
+    describe('returnPathname is neutralized to the app origin', () => {
+      const appOrigin = 'http://example.com';
+      const hostileReturnPathnames = [
+        'javascript:alert(document.domain)',
+        'https://evil.com/phishing',
+        '//evil.com/phishing',
+        '/\\evil.com/phishing',
+        'https:/evil.com',
+      ];
+
+      it.each(hostileReturnPathnames)('keeps the redirect same-origin for %s', async (returnPathname) => {
+        vi.mocked(workos.userManagement.authenticateWithCode).mockResolvedValue(mockAuthResponse);
+
+        const sealedState = await setAuthCookie(request, {
+          nonce: 'foo',
+          codeVerifier: 'test-verifier',
+          returnPathname,
+        });
+        request.nextUrl.searchParams.set('code', 'test-code');
+        request.nextUrl.searchParams.set('state', sealedState);
+
+        const handler = handleAuth();
+        const response = await handler(request);
+
+        const location = response.headers.get('Location');
+        expect(location).not.toBeNull();
+        const redirectUrl = new URL(location!);
+
+        // The scheme is never javascript:/data: and the host is never the
+        // attacker's — a hostile value can only ever become a path on our own
+        // origin (e.g. "https:/evil.com" lands at http://example.com/evil.com).
+        expect(redirectUrl.protocol).toBe('http:');
+        expect(redirectUrl.origin).toBe(appOrigin);
+        expect(redirectUrl.hostname).toBe('example.com');
+      });
+    });
+
     it('should use Response if NextResponse.redirect is not available', async () => {
       const originalRedirect = NextResponse.redirect;
       (NextResponse as Partial<typeof NextResponse>).redirect = undefined;


### PR DESCRIPTION
## What

Adds regression tests to `authkit-callback-route.spec.ts` asserting that the post-auth redirect always stays on the application's own origin, regardless of what `returnPathname` contains.

Hostile inputs covered:
- `javascript:alert(document.domain)`
- `https://evil.com/phishing`
- `//evil.com/phishing` (protocol-relative)
- `/\evil.com/phishing` (backslash → slash normalization)
- `https:/evil.com`

Each asserts the resulting `Location` has `protocol === 'http:'`, `origin === 'http://example.com'`, and `hostname === 'example.com'`.

## Why

A customer report flagged that the OAuth `state` pattern (encoding a return URL) is an open-redirect / `javascript:`-URI footgun when consumers redirect to it unvalidated.

`@workos-inc/authkit-nextjs` is **already safe by construction**: `returnPathname` is read only from the iron-session-sealed PKCE cookie (never raw URL `state`), and the callback copies only `pathname` + `search` onto the app's own origin (`authkit-callback-route.ts`). This neutralizes `javascript:`, absolute, and protocol-relative URLs.

These tests pin that invariant so a future refactor that started honoring the full URL would fail loudly. No production code changes.

## Notes

A `https:/evil.com` input lands at `http://example.com/evil.com` — a harmless path segment on our own origin, not a redirect to evil.com. The tests assert on origin/host rather than string-matching, to reflect the real security property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)