### PR TITLE
feat: add recent-auth checking (checkRecentAuth + useRecentAuth) and maxAge step-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,51 @@ const { user, loading } = useAuth({ ensureSignedIn: true });
 
 Enabling `ensureSignedIn` will redirect users to AuthKit if they attempt to access the page without being authenticated.
 
+### Re-authentication
+
+For sensitive actions you may want to require that the user authenticated _recently_, not just that they have a session. Use `checkRecentAuth` to read the access token's `auth_time` claim and decide whether to force a re-authentication.
+
+`checkRecentAuth` returns data only and never redirects, so it's safe to call as the enforcement step inside a server action or server component. It **fails closed**: a session with no usable `auth_time` (or no signed-in user) is reported as `isStale: true`.
+
+```ts
+'use server';
+
+import { checkRecentAuth, getSignInUrl } from '@workos-inc/authkit-nextjs';
+import { redirect } from 'next/navigation';
+
+export async function deleteAccount() {
+  // Require that the user authenticated within the last 5 minutes
+  const { isStale } = await checkRecentAuth({ maxAge: 300 });
+
+  if (isStale) {
+    // Send the user through re-authentication. Passing `maxAge` forwards the OIDC
+    // `max_age` parameter, so AuthKit forces a fresh login when the most recent
+    // authentication is older than `maxAge` seconds.
+    redirect(await getSignInUrl({ maxAge: 300 }));
+  }
+
+  // ...perform the sensitive action
+}
+```
+
+For client components, use the `useRecentAuth` hook to reflect recency in the UI. This is **presentation only** — always enforce recency on the server with `checkRecentAuth`.
+
+```tsx
+'use client';
+
+import { useRecentAuth } from '@workos-inc/authkit-nextjs/components';
+
+function SensitiveActionButton() {
+  const { loading, isStale } = useRecentAuth({ maxAge: 300 });
+
+  if (loading) {
+    return <button disabled>Loading…</button>;
+  }
+
+  return <button>{isStale ? 'Re-authenticate to continue' : 'Delete account'}</button>;
+}
+```
+
 ### Refreshing the session
 
 Use the `refreshSession` method in a server action or route handler to fetch the latest session details, including any changes to the user's roles or permissions.

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/react": "18.2.67",
     "@types/react-dom": "18.2.22",
     "@vitest/coverage-v8": "^3.2.4",
-    "@workos-inc/node": "^10.0.0",
+    "@workos-inc/node": "^10.7.0",
     "jsdom": "^26.1.0",
     "next": "^16.2.1",
     "oxfmt": "^0.42.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.6(@types/node@20.19.37)(jsdom@26.1.0)(terser@5.48.0))
       '@workos-inc/node':
-        specifier: ^10.0.0
-        version: 10.5.0
+        specifier: ^10.7.0
+        version: 10.7.0
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -2409,8 +2409,8 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@workos-inc/node@10.5.0':
-    resolution: {integrity: sha512-kTtDOXUDM56f0JReKDlIrTQZu4RbiR8ExwLbJE5QquvhduT/NHccbDZthILd4izT28jwtGVe0bX597w7+NMwqg==}
+  '@workos-inc/node@10.7.0':
+    resolution: {integrity: sha512-rffa9znZuIv4yo+9JRxGOLTTSxh0XhOT6jlsktgqEi9MuB9V0VFHRzLd3bTpkq+J9sgrPZNGpvX4aWNfMqt5cQ==}
     engines: {node: '>=22.11.0'}
 
   '@xtuc/ieee754@1.2.0':
@@ -5984,7 +5984,7 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@workos-inc/node@10.5.0': {}
+  '@workos-inc/node@10.7.0': {}
 
   '@xtuc/ieee754@1.2.0': {}
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,5 +2,6 @@ import { Impersonation } from './impersonation.js';
 import { AuthKitProvider, useAuth } from './authkit-provider.js';
 import { useAccessToken } from './useAccessToken.js';
 import { useTokenClaims } from './useTokenClaims.js';
+import { useRecentAuth } from './useRecentAuth.js';
 
-export { Impersonation, AuthKitProvider, useAuth, useAccessToken, useTokenClaims };
+export { Impersonation, AuthKitProvider, useAuth, useAccessToken, useTokenClaims, useRecentAuth };

--- a/src/components/useRecentAuth.spec.tsx
+++ b/src/components/useRecentAuth.spec.tsx
@@ -1,0 +1,69 @@
+import { renderHook } from '@testing-library/react';
+import { useRecentAuth } from './useRecentAuth.js';
+import { useAccessToken } from './useAccessToken.js';
+import { useTokenClaims } from './useTokenClaims.js';
+
+vi.mock('./useAccessToken.js');
+vi.mock('./useTokenClaims.js');
+
+const NOW_MS = 1_700_000_000_000;
+const NOW_S = NOW_MS / 1000;
+
+function mockAccessToken(loading: boolean) {
+  vi.mocked(useAccessToken).mockReturnValue({
+    accessToken: undefined,
+    loading,
+    error: null,
+    refresh: vi.fn(),
+    getAccessToken: vi.fn(),
+  });
+}
+
+describe('useRecentAuth', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+    mockAccessToken(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('reports recent auth as not stale', () => {
+    vi.mocked(useTokenClaims).mockReturnValue({ auth_time: NOW_S - 60 });
+
+    const { result } = renderHook(() => useRecentAuth({ maxAge: 300 }));
+
+    expect(result.current.isStale).toBe(false);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.authenticatedAt).toEqual(new Date((NOW_S - 60) * 1000));
+  });
+
+  it('reports stale auth past maxAge', () => {
+    vi.mocked(useTokenClaims).mockReturnValue({ auth_time: NOW_S - 600 });
+
+    const { result } = renderHook(() => useRecentAuth({ maxAge: 300 }));
+
+    expect(result.current.isStale).toBe(true);
+  });
+
+  it('fails closed when auth_time is absent', () => {
+    vi.mocked(useTokenClaims).mockReturnValue({});
+
+    const { result } = renderHook(() => useRecentAuth({ maxAge: 300 }));
+
+    expect(result.current.isStale).toBe(true);
+    expect(result.current.authenticatedAt).toBeNull();
+  });
+
+  it('surfaces the token loading state', () => {
+    mockAccessToken(true);
+    vi.mocked(useTokenClaims).mockReturnValue({});
+
+    const { result } = renderHook(() => useRecentAuth({ maxAge: 300 }));
+
+    expect(result.current.loading).toBe(true);
+  });
+});

--- a/src/components/useRecentAuth.ts
+++ b/src/components/useRecentAuth.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { evaluateRecentAuth } from '../utils.js';
+import { useAccessToken } from './useAccessToken.js';
+import { useTokenClaims } from './useTokenClaims.js';
+
+/**
+ * Reports how recently the current user authenticated, from the `auth_time`
+ * claim already held in client memory. Presentation only — enforce recency
+ * server-side with `checkRecentAuth`.
+ */
+export function useRecentAuth({ maxAge }: { maxAge: number }) {
+  const { loading } = useAccessToken();
+  const { auth_time } = useTokenClaims();
+
+  if (loading) {
+    return {
+      loading: true,
+      authenticatedAt: undefined,
+      isStale: undefined,
+    } as const;
+  }
+
+  const recentAuth = evaluateRecentAuth({
+    authTime: auth_time,
+    maxAgeSeconds: maxAge,
+    nowSeconds: Math.floor(Date.now() / 1000),
+  });
+
+  return { ...recentAuth, loading } as const;
+}

--- a/src/get-authorization-url.spec.ts
+++ b/src/get-authorization-url.spec.ts
@@ -70,6 +70,40 @@ describe('getAuthorizationUrl', () => {
     );
   });
 
+  it('forwards maxAge when provided', async () => {
+    vi.mocked(workos.userManagement.getAuthorizationUrl).mockReturnValue('mock-url');
+
+    await getAuthorizationUrl({ maxAge: 300 });
+
+    expect(workos.userManagement.getAuthorizationUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxAge: 300,
+      }),
+    );
+  });
+
+  it('forwards maxAge of 0 (force reauth)', async () => {
+    vi.mocked(workos.userManagement.getAuthorizationUrl).mockReturnValue('mock-url');
+
+    await getAuthorizationUrl({ maxAge: 0 });
+
+    expect(workos.userManagement.getAuthorizationUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxAge: 0,
+      }),
+    );
+  });
+
+  it('omits maxAge when not provided', async () => {
+    vi.mocked(workos.userManagement.getAuthorizationUrl).mockReturnValue('mock-url');
+
+    await getAuthorizationUrl({});
+
+    expect(workos.userManagement.getAuthorizationUrl).toHaveBeenCalledWith(
+      expect.not.objectContaining({ maxAge: expect.anything() }),
+    );
+  });
+
   describe('claim nonce', () => {
     afterEach(() => {
       delete process.env.WORKOS_CLAIM_TOKEN;

--- a/src/get-authorization-url.ts
+++ b/src/get-authorization-url.ts
@@ -41,6 +41,7 @@ async function getAuthorizationUrl({
   prompt,
   state: customState,
   redirectUri,
+  maxAge,
 }: GetAuthURLOptions = {}): Promise<GetAuthURLResult> {
   const redirectUriToUse = await (async () => {
     if (redirectUri) {
@@ -75,6 +76,7 @@ async function getAuthorizationUrl({
     codeChallenge: pkce.codeChallenge,
     codeChallengeMethod: pkce.codeChallengeMethod,
     ...(claimNonce && { claimNonce }),
+    ...(maxAge !== undefined && { maxAge }),
   });
 
   return { url, sealedState };

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export {
   type AuthkitRequestHeader,
   type HandleAuthkitHeadersOptions,
 } from './middleware-helpers.js';
-import { getTokenClaims, refreshSession, saveSession, withAuth } from './session.js';
+import { checkRecentAuth, getTokenClaims, refreshSession, saveSession, withAuth } from './session.js';
 import { validateApiKey } from './validate-api-key.js';
 import { getFeatureFlagsRuntimeClient } from './feature-flags.js';
 import { getWorkOS } from './workos.js';
@@ -27,6 +27,7 @@ export {
   authkit,
   authkitMiddleware,
   authkitProxy,
+  checkRecentAuth,
   getSignInUrl,
   getSignUpUrl,
   getFeatureFlagsRuntimeClient,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,18 @@
-import type { AuthenticationResponse, OauthTokens, User } from '@workos-inc/node';
+import type { AuthenticationResponse, OauthTokens, User, WorkOS } from '@workos-inc/node';
 import { type NextRequest } from 'next/server';
 import * as v from 'valibot';
+
+/**
+ * The options object accepted by the installed SDK's `getAuthorizationUrl`.
+ *
+ * Derived from the method authkit already calls at runtime rather than from a
+ * named type import, so the version gate below never depends on whether a given
+ * `@workos-inc/node` release exports its options type by name — it only needs
+ * the method to exist, which it does across the entire peer range. `keyof` is
+ * read from the consumer's installed version at *their* compile time, so the
+ * surface tracks the peer.
+ */
+type SdkAuthorizationUrlOptions = Parameters<WorkOS['userManagement']['getAuthorizationUrl']>[0];
 
 export interface HandleAuthOptions {
   returnPathname?: string;
@@ -85,6 +97,13 @@ export interface GetAuthURLOptions {
   loginHint?: string;
   prompt?: 'consent';
   state?: string;
+  /**
+   * Maximum allowable elapsed time, in seconds, since the user last actively
+   * authenticated (OIDC `max_age`).
+   *
+   * Requires `@workos-inc/node` >= 10.7.0, where the param was added.
+   */
+  maxAge?: 'maxAge' extends keyof SdkAuthorizationUrlOptions ? number : never;
 }
 
 export interface AuthkitMiddlewareAuth {

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -66,6 +66,11 @@ export interface JWTPayload {
    * Permissions granted to the user associated with the JWT
    */
   permissions?: string[];
+
+  /**
+   * Time of user authentication, represented as epoch seconds
+   */
+  auth_time?: number;
 }
 
 export type TokenClaims<T> = Partial<JWTPayload & T>;

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -3,7 +3,14 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { generateTestToken } from './test-helpers.js';
-import { withAuth, updateSession, refreshSession, updateSessionMiddleware, getTokenClaims } from './session.js';
+import {
+  withAuth,
+  updateSession,
+  refreshSession,
+  updateSessionMiddleware,
+  getTokenClaims,
+  checkRecentAuth,
+} from './session.js';
 import { getWorkOS } from './workos.js';
 import * as envVariables from './env-variables.js';
 
@@ -1096,6 +1103,44 @@ describe('session.ts', () => {
       const result = await getTokenClaims(token);
 
       expect(result).toMatchObject(tokenPayload);
+    });
+  });
+
+  describe('checkRecentAuth', () => {
+    async function authenticate(authTime?: number) {
+      mockSession.accessToken = await generateTestToken(authTime === undefined ? {} : { auth_time: authTime });
+      const nextHeaders = await headers();
+      nextHeaders.set(
+        'x-workos-session',
+        await sealData(mockSession, { password: process.env.WORKOS_COOKIE_PASSWORD as string }),
+      );
+    }
+
+    it('reports recent auth as not stale', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      await authenticate(now - 60);
+
+      const result = await checkRecentAuth({ maxAge: 300 });
+
+      expect(result.isStale).toBe(false);
+      expect(result.authenticatedAt).toEqual(new Date((now - 60) * 1000));
+    });
+
+    it('reports stale auth past maxAge', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      await authenticate(now - 600);
+
+      expect((await checkRecentAuth({ maxAge: 300 })).isStale).toBe(true);
+    });
+
+    it('fails closed when auth_time claim is missing', async () => {
+      await authenticate(undefined);
+
+      expect(await checkRecentAuth({ maxAge: 300 })).toEqual({ authenticatedAt: null, isStale: true });
+    });
+
+    it('fails closed when there is no authenticated user', async () => {
+      expect(await checkRecentAuth({ maxAge: 300 })).toEqual({ authenticatedAt: null, isStale: true });
     });
   });
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -29,7 +29,7 @@ import { getWorkOS } from './workos.js';
 import type { AuthenticationResponse } from '@workos-inc/node';
 import { parse, tokensToRegexp } from 'path-to-regexp';
 import { handleAuthkitHeaders } from './middleware-helpers.js';
-import { lazy, setCachePreventionHeaders } from './utils.js';
+import { evaluateRecentAuth, lazy, setCachePreventionHeaders } from './utils.js';
 
 const sessionHeaderName = 'x-workos-session';
 const middlewareHeaderName = 'x-workos-middleware';
@@ -469,6 +469,34 @@ export async function getTokenClaims<T = Record<string, unknown>>(
   }
 
   return decodeJwt<T>(token);
+}
+
+/**
+ * Check how recently the current user authenticated, using the `auth_time`
+ * claim on the access token. Returns data only — it never redirects — so it is
+ * safe to call as the enforcement step inside a sensitive server action or in a
+ * server component where you decide what to do.
+ *
+ * @example
+ * ```typescript
+ * // Guard a sensitive server action
+ * const { isStale } = await checkRecentAuth({ maxAge: 300 });
+ * if (isStale) {
+ *   return { status: 'reauth_required' };
+ * }
+ * ```
+ *
+ * @remarks
+ * To send the user through re-authentication, redirect to your sign-in route
+ * with `maxAge` (e.g. `getSignInUrl({ maxAge: 300 })`), which forwards OIDC
+ * `max_age` so the IdP forces a reauth when the most recent auth is older.
+ *
+ * Requires `@workos-inc/node` >= 10.7.0 for `maxAge` forwarding.
+ */
+export async function checkRecentAuth({ maxAge }: { maxAge: number }) {
+  const { user, accessToken } = await withAuth();
+  const authTime = user && accessToken ? (await getTokenClaims(accessToken)).auth_time : undefined;
+  return evaluateRecentAuth({ authTime, maxAgeSeconds: maxAge, nowSeconds: Math.floor(Date.now() / 1000) });
 }
 
 async function withAuth(options: { ensureSignedIn: true }): Promise<UserInfo>;

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { redirectWithFallback, errorResponseWithFallback } from './utils.js';
+import { redirectWithFallback, errorResponseWithFallback, evaluateRecentAuth } from './utils.js';
 
 describe('utils', () => {
   afterEach(() => {
@@ -120,6 +120,52 @@ describe('utils', () => {
       expect(result).toBeInstanceOf(Response);
       expect(result.status).toBe(500);
       expect(result.headers.get('Content-Type')).toBe('application/json');
+    });
+  });
+
+  describe('evaluateRecentAuth', () => {
+    const NOW = 1_700_000_000; // fixed epoch seconds
+
+    it('reports recent auth as not stale', () => {
+      const authTime = NOW - 60; // 1 minute ago
+      const result = evaluateRecentAuth({ authTime, maxAgeSeconds: 300, nowSeconds: NOW });
+
+      expect(result.isStale).toBe(false);
+      expect(result.authenticatedAt).toEqual(new Date(authTime * 1000));
+    });
+
+    it('reports auth older than maxAge as stale', () => {
+      const authTime = NOW - 600; // 10 minutes ago
+      const result = evaluateRecentAuth({ authTime, maxAgeSeconds: 300, nowSeconds: NOW });
+
+      expect(result.isStale).toBe(true);
+      expect(result.authenticatedAt).toEqual(new Date(authTime * 1000));
+    });
+
+    it('treats exactly maxAge as not stale (boundary is inclusive)', () => {
+      const result = evaluateRecentAuth({ authTime: NOW - 300, maxAgeSeconds: 300, nowSeconds: NOW });
+      expect(result.isStale).toBe(false);
+    });
+
+    it('fails closed when auth_time is missing', () => {
+      expect(evaluateRecentAuth({ authTime: undefined, maxAgeSeconds: 300, nowSeconds: NOW })).toEqual({
+        authenticatedAt: null,
+        isStale: true,
+      });
+    });
+
+    it('fails closed when auth_time is not a finite number', () => {
+      for (const bad of ['1700000000', NaN, Infinity, null, {}]) {
+        expect(evaluateRecentAuth({ authTime: bad, maxAgeSeconds: 300, nowSeconds: NOW })).toEqual({
+          authenticatedAt: null,
+          isStale: true,
+        });
+      }
+    });
+
+    it('does not treat future auth_time (clock skew) as stale', () => {
+      const result = evaluateRecentAuth({ authTime: NOW + 30, maxAgeSeconds: 300, nowSeconds: NOW });
+      expect(result.isStale).toBe(false);
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,33 @@ export function errorResponseWithFallback(errorBody: { error: { message: string;
       });
 }
 
+type EvaluateRecentAuthParameters = {
+  authTime: unknown;
+  maxAgeSeconds: number;
+  nowSeconds: number;
+};
+
+/**
+ * Evaluate whether an authentication is recent enough.
+ *
+ * Fails closed: a missing or non-finite `authTime` is reported as stale. A
+ * future `authTime` (clock skew) is treated as recent rather than stale, and
+ * the `maxAge` boundary is inclusive.
+ */
+export function evaluateRecentAuth({ authTime, maxAgeSeconds, nowSeconds }: EvaluateRecentAuthParameters) {
+  if (typeof authTime !== 'number' || !Number.isFinite(authTime)) {
+    return {
+      authenticatedAt: null,
+      isStale: true,
+    } as const;
+  }
+
+  return {
+    authenticatedAt: new Date(authTime * 1000),
+    isStale: nowSeconds - authTime > maxAgeSeconds,
+  } as const;
+}
+
 /**
  * Returns a function that can only be called once.
  * Subsequent calls will return the result of the first call.


### PR DESCRIPTION
Surface the access token's `auth_time` claim so apps can enforce step-up / reauthentication.

## What's in here

- **`checkRecentAuth` server function** — data-only recency check that fails closed (`isStale: true` when `auth_time` is missing or there's no user). It never redirects, so it's safe to call as the enforcement step inside a sensitive server action or in a server component where you decide what to do.
- **`useRecentAuth` client hook** — presentation-only recency state from claims already in client memory.
- **`evaluateRecentAuth`** — shared internal helper (in `utils.ts`) backing both. Fails closed on a missing/non-finite `auth_time`, treats a future `auth_time` (clock skew) as recent, and uses an inclusive `maxAge` boundary.
- Added `auth_time` to `JWTPayload`.

## `maxAge` step-up (OIDC `max_age`)

- `getSignInUrl` / `getSignUpUrl` / `getAuthorizationUrl` now accept `maxAge`, forwarding OIDC `max_age` so the IdP forces a reauth when the most recent auth is older. This is the redirect half of the step-up loop that `checkRecentAuth` gates.
- The `GetAuthURLOptions.maxAge` field is **version-gated via a conditional type** derived from the installed SDK (`Parameters<WorkOS['userManagement']['getAuthorizationUrl']>[0]`). On `@workos-inc/node` < 10.6 it resolves to `never` — unsettable at compile time rather than advertised and silently dropped at runtime. No false promise, no silent no-op.

## Dependencies

- **Non-breaking.** The peer range is unchanged (`@workos-inc/node` `^9.0.0 || ^10.0.0`); the conditional type self-gates per consumer.
- Dev dependency bumped to `@workos-inc/node` `^10.7.0` so the build type-checks the `maxAge` passthrough.

## Notes for reviewers

- This package is standalone (it does not depend on `@workos/authkit-session`), so `checkRecentAuth` reads `auth_time` via the existing `withAuth` + `getTokenClaims` path. That read is decode-only, consistent with `withAuth`/`getTokenClaims` — the iron-session seal (verified/refreshed in middleware) is the integrity boundary throughout the library.
- Parallels workos/authkit-tanstack-start#112.
