### PR TITLE
feat: add CallbackError with request attribution

### DIFF
--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { getPKCECookieOptions } from './cookie.js';
 import { WORKOS_CLIENT_ID } from './env-variables.js';
+import { CallbackError } from './errors.js';
 import { HandleAuthOptions } from './interfaces.js';
 import { PKCE_COOKIE_NAME, getPKCECookieNameForState, getStateFromPKCECookieValue } from './pkce.js';
 import { saveSession } from './session.js';
@@ -32,12 +33,21 @@ export function handleAuth(options: HandleAuthOptions = {}) {
     const code = requestUrl.searchParams.get('code');
     const state = requestUrl.searchParams.get('state');
 
+    // Attribution for thrown errors: which request failed and what it carried,
+    // with param values omitted since `code` is a live credential.
+    const errorContext = {
+      path: requestUrl.pathname,
+      userAgent: request.headers.get('user-agent') ?? undefined,
+      hasCode: code !== null,
+      hasState: state !== null,
+    };
+
     // We want to catch any & all errors and respond the same way, always
     // destroying the 1-use PKCE cookie to prevent replay attacks or stale
     // cookies affecting future auth attempts.
     try {
       if (!code || !state) {
-        throw new Error('Missing required auth parameter');
+        throw new CallbackError('Missing required auth parameter', 'missing_auth_params', errorContext);
       }
 
       // Derive the flow-specific cookie name from the state param so each
@@ -50,11 +60,15 @@ export function handleAuth(options: HandleAuthOptions = {}) {
 
       // CSRF verification: both channels (cookie + URL state) must be present and match
       if (!pkceCookie) {
-        throw new Error('Sign-in session could not be verified. Please try signing in again.');
+        throw new CallbackError(
+          'Sign-in session could not be verified. Please try signing in again.',
+          'missing_pkce_cookie',
+          errorContext,
+        );
       }
 
       if (state !== pkceCookie) {
-        throw new Error('OAuth state mismatch');
+        throw new CallbackError('OAuth state mismatch', 'oauth_state_mismatch', errorContext);
       }
 
       const {
@@ -72,7 +86,7 @@ export function handleAuth(options: HandleAuthOptions = {}) {
         });
 
       if (!accessToken || !refreshToken) {
-        throw new Error('response is missing tokens');
+        throw new CallbackError('response is missing tokens', 'missing_tokens', errorContext);
       }
 
       // If baseURL is provided, use it instead of request.nextUrl

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -12,6 +12,40 @@ export class AuthKitError extends Error {
   }
 }
 
+export type CallbackErrorCode =
+  | 'missing_auth_params'
+  | 'missing_pkce_cookie'
+  | 'oauth_state_mismatch'
+  | 'missing_tokens';
+
+export interface CallbackErrorContext {
+  path?: string;
+  userAgent?: string;
+  hasCode?: boolean;
+  hasState?: boolean;
+}
+
+// Carries the request that actually threw, so `onError` consumers can report
+// accurate attribution without relying on ambient (per-request) APM scope,
+// which can misattribute under concurrency.
+export class CallbackError extends AuthKitError {
+  readonly code: CallbackErrorCode;
+  readonly path?: string;
+  readonly userAgent?: string;
+  readonly hasCode?: boolean;
+  readonly hasState?: boolean;
+
+  constructor(message: string, code: CallbackErrorCode, context?: CallbackErrorContext) {
+    super(message);
+    this.name = 'CallbackError';
+    this.code = code;
+    this.path = context?.path;
+    this.userAgent = context?.userAgent;
+    this.hasCode = context?.hasCode;
+    this.hasState = context?.hasState;
+  }
+}
+
 export interface TokenRefreshErrorContext {
   userId?: string;
   sessionId?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { getSignInUrl, getSignUpUrl, signOut, switchToOrganization } from './auth.js';
 import { handleAuth } from './authkit-callback-route.js';
-import { AuthKitError, TokenRefreshError } from './errors.js';
+import { AuthKitError, CallbackError, TokenRefreshError } from './errors.js';
 import { authkit, authkitMiddleware, authkitProxy } from './middleware.js';
 export {
   applyResponseHeaders,
@@ -21,8 +21,11 @@ import { getWorkOS } from './workos.js';
 
 export * from './interfaces.js';
 
+export type { CallbackErrorCode, CallbackErrorContext } from './errors.js';
+
 export {
   AuthKitError,
+  CallbackError,
   TokenRefreshError,
   authkit,
   authkitMiddleware,


### PR DESCRIPTION
## Summary

- Adds a `CallbackError` class (extends `AuthKitError`) that carries the failing request's context — `path`, `userAgent`, and `hasCode`/`hasState` flags — plus a stable, machine-readable `code`.
- Replaces the generic `Error` throws in `handleAuth`'s callback route with `CallbackError`, so `onError` consumers can attribute a failure to a specific request instead of relying on ambient per-request APM scope (which misattributes under concurrency).
- Omits the raw `code`/`state` param values from the attached context, since `code` is a live credential — only presence flags are recorded.
- Exports `CallbackError` and the `CallbackErrorCode` / `CallbackErrorContext` types from the package entry point for consumer use.
