### PR TITLE
fix: Preserve session on transient refresh failures

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -49,17 +49,26 @@ export class CallbackError extends AuthKitError {
 export interface TokenRefreshErrorContext {
   userId?: string;
   sessionId?: string;
+  /**
+   * Whether the refresh failed for a transient reason (network error, timeout,
+   * 429, or 5xx) rather than a terminal one (the refresh token is dead). When
+   * `true`, the existing session is still valid and the caller should keep it
+   * and retry rather than signing the user out.
+   */
+  isTransient?: boolean;
 }
 
 export class TokenRefreshError extends AuthKitError {
   readonly userId?: string;
   readonly sessionId?: string;
+  readonly isTransient: boolean;
 
   constructor(message: string, cause?: unknown, context?: TokenRefreshErrorContext) {
     super(message, cause);
     this.name = 'TokenRefreshError';
     this.userId = context?.userId;
     this.sessionId = context?.sessionId;
+    this.isTransient = context?.isTransient ?? false;
   }
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -152,7 +152,16 @@ export interface AuthkitOptions {
     impersonator?: Impersonator;
     organizationId?: string;
   }) => void | Promise<void>;
-  onSessionRefreshError?: (params: { error?: unknown; request: NextRequest }) => void | Promise<void>;
+  onSessionRefreshError?: (params: {
+    error?: unknown;
+    request: NextRequest;
+    /**
+     * Whether the refresh failed for a transient reason (network error,
+     * timeout, 429, or 5xx) rather than a terminal one. When `true` the sealed
+     * session cookie is preserved for a later retry instead of being cleared.
+     */
+    isTransient: boolean;
+  }) => void | Promise<void>;
 }
 
 export interface AuthkitResponse {

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -402,6 +402,84 @@ describe('session.ts', () => {
       );
     });
 
+    it.each([
+      ['a rate limit (429)', Object.assign(new Error('Too many requests'), { status: 429 })],
+      ['a server error (503)', Object.assign(new Error('Service unavailable'), { status: 503 })],
+      ['a request timeout (408)', Object.assign(new Error('Request timeout'), { status: 408 })],
+      ['a network error', new TypeError('fetch failed')],
+    ])('should preserve the cookie when refreshing fails transiently: %s', async (_label, transientError) => {
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      mockSession.accessToken = await generateTestToken({}, true);
+
+      (jwtVerify as Mock).mockImplementation(() => {
+        throw new Error('Invalid token');
+      });
+
+      vi.spyOn(workos.userManagement, 'authenticateWithRefreshToken').mockRejectedValue(transientError);
+
+      const request = new NextRequest(new URL('http://example.com'));
+
+      request.cookies.set(
+        'wos-session',
+        await sealData(mockSession, { password: process.env.WORKOS_COOKIE_PASSWORD as string }),
+      );
+
+      const response = await updateSessionMiddleware(
+        request,
+        true,
+        {
+          enabled: false,
+          unauthenticatedPaths: [],
+        },
+        process.env.NEXT_PUBLIC_WORKOS_REDIRECT_URI as string,
+        [],
+      );
+
+      expect(response.status).toBe(200);
+      // The sealed session cookie must not be cleared on a transient failure.
+      expect(response.headers.get('Set-Cookie') ?? '').not.toContain('wos-session=;');
+      expect(console.log).toHaveBeenCalledWith(
+        'Failed to refresh due to a transient error. Preserving the session cookie so it can be retried.',
+        transientError,
+      );
+    });
+
+    it('should delete the cookie for a terminal refresh failure (invalid_grant)', async () => {
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      mockSession.accessToken = await generateTestToken({}, true);
+
+      (jwtVerify as Mock).mockImplementation(() => {
+        throw new Error('Invalid token');
+      });
+
+      const terminalError = Object.assign(new Error('invalid_grant'), { status: 400 });
+      vi.spyOn(workos.userManagement, 'authenticateWithRefreshToken').mockRejectedValue(terminalError);
+
+      const request = new NextRequest(new URL('http://example.com'));
+
+      request.cookies.set(
+        'wos-session',
+        await sealData(mockSession, { password: process.env.WORKOS_COOKIE_PASSWORD as string }),
+      );
+
+      const response = await updateSessionMiddleware(
+        request,
+        true,
+        {
+          enabled: false,
+          unauthenticatedPaths: [],
+        },
+        process.env.NEXT_PUBLIC_WORKOS_REDIRECT_URI as string,
+        [],
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Set-Cookie')).toContain('wos-session=;');
+      expect(console.log).toHaveBeenCalledWith('Failed to refresh. Deleting cookie.', terminalError);
+    });
+
     describe('middleware auth', () => {
       it('should redirect unauthenticated users on protected routes', async () => {
         vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/src/session.spec.ts
+++ b/src/session.spec.ts
@@ -407,6 +407,12 @@ describe('session.ts', () => {
       ['a server error (503)', Object.assign(new Error('Service unavailable'), { status: 503 })],
       ['a request timeout (408)', Object.assign(new Error('Request timeout'), { status: 408 })],
       ['a network error', new TypeError('fetch failed')],
+      // The SDK re-wraps a raw network TypeError in a plain Error with the
+      // TypeError as its cause; the classifier must follow the cause chain.
+      [
+        'an SDK-wrapped network error',
+        new Error('Unexpected error: TypeError: fetch failed', { cause: new TypeError('fetch failed') }),
+      ],
     ])('should preserve the cookie when refreshing fails transiently: %s', async (_label, transientError) => {
       vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -1026,6 +1032,7 @@ describe('session.ts', () => {
       expect(mockErrorCallback).toHaveBeenCalledWith({
         error: mockError,
         request,
+        isTransient: false,
       });
     });
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -378,7 +378,7 @@ async function updateSession(
       }
     }
 
-    options.onSessionRefreshError?.({ error: e, request });
+    options.onSessionRefreshError?.({ error: e, request, isTransient });
 
     const { url: authorizationUrl, sealedState } = await getAuthorizationUrl({
       returnPathname: getReturnPathname(request.url),
@@ -637,28 +637,47 @@ function isTokenExpiring(accessToken: string, refreshBufferSeconds?: number): bo
 // (429), and 5xx.
 const RETRYABLE_REFRESH_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
 
+// A network-level fetch failure surfaces as a TypeError ("fetch failed" /
+// "Failed to fetch"). Match its message so an unrelated programming TypeError
+// isn't misclassified as a transient (and therefore session-preserving) error.
+const NETWORK_ERROR_MESSAGE = /fetch failed|failed to fetch|network|load failed|terminated/i;
+
+// A raw network TypeError is not an HttpClientError, so the WorkOS SDK re-wraps
+// it in a plain Error whose `cause` is the original TypeError. Follow the cause
+// chain to recognize it.
+function isNetworkError(error: unknown): boolean {
+  if (error instanceof TypeError) {
+    return NETWORK_ERROR_MESSAGE.test(error.message);
+  }
+
+  if (error instanceof Error && error.cause != null && error.cause !== error) {
+    return isNetworkError(error.cause);
+  }
+
+  return false;
+}
+
 /**
  * Determines whether a failed refresh is transient (should preserve the
  * session and be retried) rather than terminal (the refresh token is dead and
  * the user must re-authenticate).
  *
- * Mirrors the WorkOS SDK's own retry classification: a network-level failure
- * surfaces as a `TypeError` from the fetch client once its internal retries are
- * exhausted, and transient HTTP responses carry a numeric `status` in the
- * retryable set. Anything else (a terminal `invalid_grant` at 400, a 401, or an
- * unrecognized error) is treated as terminal.
+ * Mirrors the WorkOS SDK's own retry classification: transient HTTP responses
+ * (request timeout normalized to `408`, `429`, and `5xx`) surface as an
+ * exception carrying a retryable numeric `status`, and a network-level failure
+ * surfaces as a `TypeError` (wrapped by the SDK in an `Error` with the
+ * `TypeError` as its `cause`). Anything else (a terminal `invalid_grant` at
+ * 400, a 401, or an unrecognized error) is treated as terminal.
  */
 export function isTransientRefreshError(error: unknown): boolean {
-  if (error instanceof TypeError) {
-    return true;
-  }
-
   if (typeof error === 'object' && error !== null && 'status' in error) {
     const { status } = error;
-    return typeof status === 'number' && RETRYABLE_REFRESH_STATUS_CODES.has(status);
+    if (typeof status === 'number' && RETRYABLE_REFRESH_STATUS_CODES.has(status)) {
+      return true;
+    }
   }
 
-  return false;
+  return isNetworkError(error);
 }
 
 export async function getSessionFromCookie(request?: NextRequest) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -348,18 +348,34 @@ async function updateSession(
       }
     }
 
+    // Only tear down the session for a terminal failure. A transient failure
+    // (network error, request timeout, 429, or 5xx that survived the SDK's
+    // internal retries) is not a signal that the refresh token is dead —
+    // deleting the cookie here would turn a brief outage into a forced
+    // re-authentication, and the still-valid refresh token would be lost. Keep
+    // the sealed cookie so a later request refreshes successfully once the
+    // condition clears.
+    const isTransient = isTransientRefreshError(e);
+
     if (options.debug) {
-      console.log('Failed to refresh. Deleting cookie.', e);
+      console.log(
+        isTransient
+          ? 'Failed to refresh due to a transient error. Preserving the session cookie so it can be retried.'
+          : 'Failed to refresh. Deleting cookie.',
+        e,
+      );
     }
 
-    // When we need to delete a cookie, return it as a header as you can't delete cookies from edge middleware
-    const deleteCookie = `${cookieName}=; Expires=${new Date(0).toUTCString()}; ${getCookieOptions(request.url, true, true)}`;
-    newRequestHeaders.append('Set-Cookie', deleteCookie);
+    if (!isTransient) {
+      // When we need to delete a cookie, return it as a header as you can't delete cookies from edge middleware
+      const deleteCookie = `${cookieName}=; Expires=${new Date(0).toUTCString()}; ${getCookieOptions(request.url, true, true)}`;
+      newRequestHeaders.append('Set-Cookie', deleteCookie);
 
-    // Delete JWT cookie if eagerAuth is enabled
-    if (options.eagerAuth) {
-      const deleteJwtCookie = getJwtCookie(null, request.url, true);
-      newRequestHeaders.append('Set-Cookie', deleteJwtCookie);
+      // Delete JWT cookie if eagerAuth is enabled
+      if (options.eagerAuth) {
+        const deleteJwtCookie = getJwtCookie(null, request.url, true);
+        newRequestHeaders.append('Set-Cookie', deleteJwtCookie);
+      }
     }
 
     options.onSessionRefreshError?.({ error: e, request });
@@ -414,7 +430,7 @@ async function refreshSession({
     throw new TokenRefreshError(
       `Failed to refresh session: ${error instanceof Error ? error.message : String(error)}`,
       error,
-      getSessionErrorContext(session),
+      { ...getSessionErrorContext(session), isTransient: isTransientRefreshError(error) },
     );
   }
 
@@ -613,6 +629,36 @@ function isTokenExpiring(accessToken: string, refreshBufferSeconds?: number): bo
   } catch {
     return false;
   }
+}
+
+// HTTP statuses the WorkOS SDK treats as idempotent/retryable and retries
+// internally. If one of these still surfaces, the failure is transient rather
+// than a dead refresh token: request timeouts (normalized to 408), rate limits
+// (429), and 5xx.
+const RETRYABLE_REFRESH_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+
+/**
+ * Determines whether a failed refresh is transient (should preserve the
+ * session and be retried) rather than terminal (the refresh token is dead and
+ * the user must re-authenticate).
+ *
+ * Mirrors the WorkOS SDK's own retry classification: a network-level failure
+ * surfaces as a `TypeError` from the fetch client once its internal retries are
+ * exhausted, and transient HTTP responses carry a numeric `status` in the
+ * retryable set. Anything else (a terminal `invalid_grant` at 400, a 401, or an
+ * unrecognized error) is treated as terminal.
+ */
+export function isTransientRefreshError(error: unknown): boolean {
+  if (error instanceof TypeError) {
+    return true;
+  }
+
+  if (typeof error === 'object' && error !== null && 'status' in error) {
+    const { status } = error;
+    return typeof status === 'number' && RETRYABLE_REFRESH_STATUS_CODES.has(status);
+  }
+
+  return false;
 }
 
 export async function getSessionFromCookie(request?: NextRequest) {


### PR DESCRIPTION
## Summary

When the access token is already invalid/expired and a refresh is required, `updateSession` caught **any** error from `authenticateWithRefreshToken` and deleted the session cookie + redirected to sign-in. That includes *transient* failures (network error, request timeout, `429`, `5xx`) that survive the SDK's internal retries — so a brief outage discards a still-valid refresh token and forces re-authentication (the BaseTen lockout pattern). The proactive/`isExpiring` path was already resilient, but only while the current token was still valid.

This classifies the failure and only tears down the session for a **terminal** error. On a transient failure the sealed cookie is kept, so a later request refreshes successfully once the condition clears.

```ts
// session.ts — reactive refresh catch
const isTransient = isTransientRefreshError(e);
if (!isTransient) {
  // delete wos-session cookie (+ jwt cookie) and redirect to sign-in  ← unchanged terminal behavior
}
options.onSessionRefreshError?.({ error: e, request });
// transient: cookie left intact; request still returns unauthenticated for now
```

Classification mirrors the SDK's own retry rules — a network failure surfaces as a `TypeError` from the fetch client once retries are exhausted; transient HTTP responses carry a retryable numeric `status`:

```ts
const RETRYABLE_REFRESH_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);

export function isTransientRefreshError(error: unknown): boolean {
  if (error instanceof TypeError) return true; // network / DNS / connection reset
  if (typeof error === 'object' && error !== null && 'status' in error) {
    const { status } = error;
    return typeof status === 'number' && RETRYABLE_REFRESH_STATUS_CODES.has(status);
  }
  return false; // terminal: invalid_grant (400), 401, or unrecognized
}
```

`refreshSession()` (the explicit helper) still throws `TokenRefreshError`, now carrying an `isTransient` flag so callers can keep the session and retry instead of signing the user out.

Terminal behavior is unchanged: `invalid_grant`/`401`/unrecognized errors still clear the cookie and redirect.

## Test plan
- `pnpm test` (405 tests pass), `pnpm typecheck`, `pnpm lint` all green.
- New `session.spec.ts` coverage: parametrized transient cases (`429`, `503`, `408`, network `TypeError`) assert the `wos-session` cookie is **not** cleared; a terminal `invalid_grant` (`400`) case asserts the cookie **is** cleared.

Part of the AuthKit refresh-token DX work (server returns `429` for transient refresh lock timeouts in workos/workos#66577; typed transient/terminal `session.refresh()` in workos/workos-node#1663).


Link to Devin session: https://app.devin.ai/sessions/fc39103abf694f90b1c92dd714a81461
Requested by: @m0tzy