### PR TITLE
fix: defer initial token refresh until first subscriber

### DIFF
--- a/src/components/tokenStore.spec.ts
+++ b/src/components/tokenStore.spec.ts
@@ -827,5 +827,68 @@ describe('tokenStore', () => {
 
       expect(result).toBe(token);
     });
+
+    describe('deferred initial refresh scheduling', () => {
+      const makeJwt = (payload: Record<string, unknown>) =>
+        `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${btoa(JSON.stringify(payload))}.mock-signature`;
+
+      const expiringJwt = () => {
+        const now = Math.floor(Date.now() / 1000);
+        return makeJwt({ sub: 'user_123', sid: 'session_123', iat: now - 3600, exp: now + 30 });
+      };
+
+      it('should not schedule a refresh timer during construction, even for an expiring token', () => {
+        setupMockEnv(`workos-access-token=${expiringJwt()};`);
+
+        new TokenStore();
+
+        expect(vi.getTimerCount()).toBe(0);
+        expect(mockRefreshAccessTokenAction).not.toHaveBeenCalled();
+      });
+
+      it('should schedule the refresh when the first subscriber attaches', async () => {
+        const now = Math.floor(Date.now() / 1000);
+        const freshToken = makeJwt({ sub: 'user_123', sid: 'session_123', iat: now, exp: now + 3600 });
+        mockRefreshAccessTokenAction.mockResolvedValue({ accessToken: freshToken });
+
+        setupMockEnv(`workos-access-token=${expiringJwt()};`);
+        const store = new TokenStore();
+
+        store.subscribe(() => {});
+        expect(vi.getTimerCount()).toBe(1);
+
+        // Expiring token schedules an immediate refresh
+        await vi.runOnlyPendingTimersAsync();
+        await Promise.resolve();
+
+        expect(mockRefreshAccessTokenAction).toHaveBeenCalledTimes(1);
+        expect(store.getSnapshot().token).toBe(freshToken);
+      });
+
+      it('should schedule the deferred refresh only once across subscribers', () => {
+        setupMockEnv(`workos-access-token=${expiringJwt()};`);
+        const store = new TokenStore();
+
+        const unsubscribe = store.subscribe(() => {});
+        expect(vi.getTimerCount()).toBe(1);
+
+        // Last unsubscribe clears the timer; a new subscriber must not re-run
+        // the initial scheduling
+        unsubscribe();
+        expect(vi.getTimerCount()).toBe(0);
+
+        store.subscribe(() => {});
+        expect(vi.getTimerCount()).toBe(0);
+      });
+
+      it('should not schedule on subscribe when the initial token is opaque', () => {
+        setupMockEnv('workos-access-token=opaque-token;');
+        const store = new TokenStore();
+
+        store.subscribe(() => {});
+
+        expect(vi.getTimerCount()).toBe(0);
+      });
+    });
   });
 });

--- a/src/components/tokenStore.spec.ts
+++ b/src/components/tokenStore.spec.ts
@@ -865,20 +865,31 @@ describe('tokenStore', () => {
         expect(store.getSnapshot().token).toBe(freshToken);
       });
 
-      it('should schedule the deferred refresh only once across subscribers', () => {
+      it('should not schedule again while other subscribers remain', () => {
+        setupMockEnv(`workos-access-token=${expiringJwt()};`);
+        const store = new TokenStore();
+
+        store.subscribe(() => {});
+        expect(vi.getTimerCount()).toBe(1);
+
+        store.subscribe(() => {});
+        expect(vi.getTimerCount()).toBe(1);
+      });
+
+      it('should restore the refresh timer when a subscriber attaches after all unsubscribed', () => {
         setupMockEnv(`workos-access-token=${expiringJwt()};`);
         const store = new TokenStore();
 
         const unsubscribe = store.subscribe(() => {});
         expect(vi.getTimerCount()).toBe(1);
 
-        // Last unsubscribe clears the timer; a new subscriber must not re-run
-        // the initial scheduling
+        // Last unsubscribe clears the timer
         unsubscribe();
         expect(vi.getTimerCount()).toBe(0);
 
+        // A later subscriber restores background refresh for the cached token
         store.subscribe(() => {});
-        expect(vi.getTimerCount()).toBe(0);
+        expect(vi.getTimerCount()).toBe(1);
       });
 
       it('should not schedule on subscribe when the initial token is opaque', () => {

--- a/src/components/tokenStore.ts
+++ b/src/components/tokenStore.ts
@@ -41,15 +41,17 @@ export class TokenStore {
       error: null,
     };
 
-    /* istanbul ignore next */
     if (initialToken) {
       // Mark as consumed if we found a token
       this.fastCookieConsumed = true;
-      // Schedule refresh based on token expiry
-      const tokenData = this.parseToken(initialToken);
-      if (tokenData) {
-        this.scheduleRefresh(tokenData.timeUntilExpiry);
-      }
+      // The store is constructed at module-evaluation time, before hydration.
+      // A refresh timer that fires before Next.js initializes its router
+      // action queue makes the Server Action throw inside React's
+      // startTransition, and the action promise never settles — wedging
+      // refreshPromise for the rest of the page lifetime. Defer scheduling
+      // until the first subscriber attaches (subscribers attach from effects,
+      // which run after hydration).
+      this.initialRefreshPending = true;
     }
   }
 
@@ -57,9 +59,18 @@ export class TokenStore {
   private refreshPromise: Promise<string | undefined> | null = null;
   private refreshTimeout: ReturnType<typeof setTimeout> | undefined;
   private fastCookieConsumed = false;
+  private initialRefreshPending = false;
 
   subscribe = (listener: () => void) => {
     this.listeners.add(listener);
+
+    if (this.initialRefreshPending) {
+      this.initialRefreshPending = false;
+      const tokenData = this.parseToken(this.state.token);
+      if (tokenData) {
+        this.scheduleRefresh(tokenData.timeUntilExpiry);
+      }
+    }
     return () => {
       this.listeners.delete(listener);
       if (this.listeners.size === 0 && this.refreshTimeout) {
@@ -400,6 +411,7 @@ export class TokenStore {
     this.state = { token: undefined, loading: false, error: null };
     this.refreshPromise = null;
     this.fastCookieConsumed = false;
+    this.initialRefreshPending = false;
     if (this.refreshTimeout) {
       clearTimeout(this.refreshTimeout);
       this.refreshTimeout = undefined;

--- a/src/components/tokenStore.ts
+++ b/src/components/tokenStore.ts
@@ -42,16 +42,13 @@ export class TokenStore {
     };
 
     if (initialToken) {
-      // Mark as consumed if we found a token
+      // Mark as consumed if we found a token. Refresh scheduling is deferred
+      // to the first subscriber: the store is constructed at module-evaluation
+      // time, before hydration, and a refresh timer that fires before Next.js
+      // initializes its router action queue makes the Server Action throw
+      // inside React's startTransition without ever settling the action
+      // promise — wedging refreshPromise for the rest of the page lifetime.
       this.fastCookieConsumed = true;
-      // The store is constructed at module-evaluation time, before hydration.
-      // A refresh timer that fires before Next.js initializes its router
-      // action queue makes the Server Action throw inside React's
-      // startTransition, and the action promise never settles — wedging
-      // refreshPromise for the rest of the page lifetime. Defer scheduling
-      // until the first subscriber attaches (subscribers attach from effects,
-      // which run after hydration).
-      this.initialRefreshPending = true;
     }
   }
 
@@ -59,13 +56,15 @@ export class TokenStore {
   private refreshPromise: Promise<string | undefined> | null = null;
   private refreshTimeout: ReturnType<typeof setTimeout> | undefined;
   private fastCookieConsumed = false;
-  private initialRefreshPending = false;
 
   subscribe = (listener: () => void) => {
     this.listeners.add(listener);
 
-    if (this.initialRefreshPending) {
-      this.initialRefreshPending = false;
+    // Unsubscribing the last listener clears the refresh timer, so restore it
+    // whenever the store goes from zero to one subscribers. Subscribers attach
+    // from effects, which run after hydration, so a timer scheduled here can
+    // never dispatch a Server Action before the router is ready.
+    if (this.listeners.size === 1 && !this.refreshTimeout) {
       const tokenData = this.parseToken(this.state.token);
       if (tokenData) {
         this.scheduleRefresh(tokenData.timeUntilExpiry);
@@ -411,7 +410,6 @@ export class TokenStore {
     this.state = { token: undefined, loading: false, error: null };
     this.refreshPromise = null;
     this.fastCookieConsumed = false;
-    this.initialRefreshPending = false;
     if (this.refreshTimeout) {
       clearTimeout(this.refreshTimeout);
       this.refreshTimeout = undefined;


### PR DESCRIPTION
## Summary

- The client `TokenStore` singleton is constructed at module-evaluation time, before hydration. When the middleware-set fast cookie held an already-expiring token, the constructor scheduled a **0ms refresh timer** that could fire before Next.js initialized its router action queue.
- When that happens, the Server Action dispatch throws `Internal Next.js error: Router action dispatched before initialization` (E668) inside React 19's `startTransition`, which routes the error to `reportGlobalError` without settling the action promise. `_refreshToken`'s `catch`/`finally` never run, so `refreshPromise` stays pending for the rest of the page lifetime — every subsequent `getAccessToken`/`getAccessTokenSilently`/`refresh` call returns the same hung promise and token refresh on that tab is permanently dead until reload.
- Fix: the constructor now records the initial token but defers `scheduleRefresh` to the first `subscribe()` call. Subscribers attach via `useSyncExternalStore` from effects, which run after hydration, so the router action queue is guaranteed to be initialized before any timer can dispatch a Server Action.
- Nothing is lost for the expired-token case: `useAccessToken`'s mount effect already calls `getAccessTokenSilently()` post-hydration, which refreshes an expiring token immediately. Background refresh with zero subscribers was already unsupported (unsubscribing the last listener clears the timer), so deferring to first-subscribe matches the store's existing lifecycle.

Closes #463
